### PR TITLE
chore(scripts): add shared https dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev1": "NODE_OPTIONS=--dns-result-order=ipv4first next dev",
     "turbo": "next dev --turbopack",
     "dev": "next dev",
+    "dev:https": "next dev --experimental-https --hostname localhost --port 3000",
     "build": "next build",
     "build:production": "next build",
     "start": "next start",


### PR DESCRIPTION
## Summary
- Jira: ---
- What changed:
  - Добавлен общий script `dev:https` в `package.json`:
    - `next dev --experimental-https --hostname localhost --port 3000`
  - Цель: единая HTTPS-команда для локального запуска в strict-браузерах (Safari и т.п.) без зависимости от локальных cert-файлов.

## Scope
### In scope
- Обновление `package.json` (только scripts).
- Поддержка единого developer flow для локального HTTPS.

### Out of scope
- Изменения SSR/RTK Query/Auth/UI логики.
- Изменения proxy/tunnel/network конфигурации.
- Любые runtime-изменения приложения.

## Architecture impact
- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

If architectural change is checked:
- add label `policy-change`
- fill `Contract change` section
- update `.ai/policy.md` version metadata

## Contract change
- What changed: N/A
- Why: N/A
- Impact/Migration: N/A
- Policy version updated: N/A

## Mandatory checklist
- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence
### Automated
- Commands and result:
  - `pnpm run ci:check` ✅ passed (`lint + typecheck + build`)
  - Есть существующие warnings (без ошибок), в т.ч. `no-console`, `react-hooks/exhaustive-deps`, `autoprefixer`.

### Manual
- Scenario 1:
  - `pnpm run dev:https`
  - Открыть `https://localhost:3000` в Safari.
  - Ожидание: приложение открывается по HTTPS, без forced redirect на невалидный URL.
- Scenario 2:
  - `pnpm run dev`
  - Открыть `http://localhost:3000` в Chrome.
  - Ожидание: стандартный HTTP dev flow не изменился.

## Risks and Rollback
- Risks:
  - Низкий риск: добавлен только новый npm script.
  - Возможна путаница у разработчиков между `dev` (HTTP) и `dev:https` (HTTPS).
- Rollback plan:
  - Откатить commit `d261fb1` или удалить строку `dev:https` из `package.json`.
