### PR TITLE
SCRUM-148 fix(post-card): reserve image space to reduce CLS

### DIFF
--- a/src/entities/posts/ui/PostCard/PostCard.module.scss
+++ b/src/entities/posts/ui/PostCard/PostCard.module.scss
@@ -1,10 +1,15 @@
+.postCard {
+  width: 100%;
+}
+
 .postImageWrapper {
+  position: relative;
   display: block;
+  width: 100%;
+  aspect-ratio: 234 / 228;
   overflow: hidden;
 }
 
 .postImage {
-  width: 100%;
-  height: auto;
   object-fit: cover;
 }

--- a/src/entities/posts/ui/PostCard/PostCard.tsx
+++ b/src/entities/posts/ui/PostCard/PostCard.tsx
@@ -25,8 +25,7 @@ export const PostCard: React.FC<PostCardProps> = ({ post }) => {
           {...IMAGE_LOADING_STRATEGY.default}
           src={post.images[0]?.url || DEFAULT_IMAGE}
           alt={`Post by ${post.userName}`}
-          width={342}
-          height={228}
+          fill
           sizes={IMAGE_SIZES.POST_CARD}
           className={s.postImage}
         />


### PR DESCRIPTION
## Summary
Стабилизирован `PostCard`: добавлено reserved space для изображения через `aspect-ratio`, а `next/image` переведён на `fill`, чтобы убрать `unsized image element` warning и снизить CLS.

## Jira
`SCRUM-148`

## What changed
- Обновлён `src/entities/posts/ui/PostCard/PostCard.tsx`: `Image` переведён с `width/height` на `fill`.
- Обновлён `src/entities/posts/ui/PostCard/PostCard.module.scss`:
- добавлены `position: relative`, `width: 100%`, `aspect-ratio: 234 / 228` для `.postImageWrapper`;
- сохранён `object-fit: cover` для изображения;
- добавлен `.postCard { width: 100%; }`.

## Scope
### In scope
- Отрисовка карточек постов в `ProfilePosts` через `PostCard`.
- Резервирование места под изображение до его загрузки.

### Out of scope
- Изменения других компонентов с изображениями (`PublicPost`, `PostModal` и т.д.).
- Изменения архитектурных контрактов и governance-файлов.

## Architecture impact
- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

If architectural change is checked:
- add label `policy-change`
- fill `Contract change` section
- update `.ai/policy.md` version metadata

## Contract change
### What changed:
`N/A`

### Why:
`N/A`

### Impact/Migration:
`N/A`

### Policy version updated:
`N/A`

## Mandatory checklist
- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence
### Automated
Commands and result:
- `pnpm run ci:check` — passed (`lint`, `typecheck`, `build` completed successfully; existing unrelated warnings remained unchanged).

### Manual
Scenario 1:
- Открыть `/profile/[id]` с сеткой постов, включить throttling (Slow 3G), обновить страницу.
- Ожидание: карточки сразу занимают фиксированную высоту, скачка layout при загрузке изображений нет.

Scenario 2:
- Запустить Lighthouse для страницы профиля (mobile).
- Ожидание: warning `unsized image element` для `PostCard` отсутствует, CLS лучше относительно baseline.

## Risks and Rollback
### Risks:
- Фиксированный `aspect-ratio` может усиливать кроп изображений с нетипичными пропорциями.
- При будущих изменениях сетки нужно синхронизировать ratio с визуальными требованиями.

### Rollback plan:
- Revert commit `58ca958` (`SCRUM-148 fix(post-card): reserve image space to reduce CLS`).
