### PR TITLE
SCRUM-152-P1-Route-Auth-based-Code-Splitting

### DIFF
--- a/src/app/RootLayoutClient.tsx
+++ b/src/app/RootLayoutClient.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { ReactNode, useEffect, useState } from 'react'
+import { lazy, ReactNode, Suspense, useEffect, useState } from 'react'
 
-import CreatePostWrapper from '@/features/posts/ui/CreatePostWrapper/CreatePostWrapper'
 import { useAuthUiState } from '@/features/posts/utils/useAuthUiState'
-import { Sidebar, SidebarSkeleton } from '@/widgets/Sidebar'
+import { SidebarSkeleton } from '@/widgets/Sidebar/components/SidebarSkeleton'
 import { useSearchParams } from 'next/navigation'
 
 import s from './RootLayoutClient.module.scss'
@@ -12,6 +11,16 @@ import s from './RootLayoutClient.module.scss'
 type Props = {
   children: ReactNode
 }
+
+const Sidebar = lazy(() =>
+  import('@/widgets/Sidebar').then(module => ({
+    default: module.Sidebar,
+  }))
+)
+
+const CreatePostWrapper = lazy(
+  () => import('@/features/posts/ui/CreatePostWrapper/CreatePostWrapper')
+)
 
 export const RootLayoutClient = ({ children }: Props) => {
   const { status } = useAuthUiState()
@@ -45,7 +54,11 @@ export const RootLayoutClient = ({ children }: Props) => {
   return (
     <main className={s.main}>
       <div className={s.wrapper}>
-        {showSidebar && <Sidebar />}
+        {showSidebar && (
+          <Suspense fallback={null}>
+            <Sidebar />
+          </Suspense>
+        )}
         {shouldRenderSidebarSkeleton && <SidebarSkeleton />}
         <div
           className={`${s.content} ${shouldReserveSidebarSpace ? s['content--withSidebar'] : s['content--withoutSidebar']}`}
@@ -53,7 +66,11 @@ export const RootLayoutClient = ({ children }: Props) => {
           {children}
         </div>
       </div>
-      {isCreatePostOpen && <CreatePostWrapper />}
+      {isCreatePostOpen && (
+        <Suspense fallback={null}>
+          <CreatePostWrapper />
+        </Suspense>
+      )}
     </main>
   )
 }

--- a/src/shared/composites/Carousel/Carousel.tsx
+++ b/src/shared/composites/Carousel/Carousel.tsx
@@ -1,16 +1,14 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import type { EmblaOptionsType } from './EmblaCarousel'
+
+import { lazy, Suspense, type FC } from 'react'
 
 import { UserImage } from '@/entities/users/api/api.types'
 import { IMAGE_LOADING_STRATEGY, IMAGE_SIZES } from '@/shared/constant'
-import { ArrowBackSimple, ArrowForwardSimple } from '@/shared/ui'
-import useEmblaCarousel from 'embla-carousel-react'
 import Image from 'next/image'
 
 import s from './Carousel.module.scss'
 
-type EmblaOptionsType = Parameters<typeof useEmblaCarousel>[0]
-
-type PropType = {
+type CarouselProps = {
   slides: UserImage[] | string[]
   options?: EmblaOptionsType
   filtersState?: Record<number, string>
@@ -19,132 +17,89 @@ type PropType = {
   priorityFirstImage?: boolean
 }
 
-export const Carousel: React.FC<PropType> = props => {
-  const {
-    slides,
-    options,
-    filtersState,
-    onSlideChange,
-    imageSizes = IMAGE_SIZES.PUBLIC_POST,
-    priorityFirstImage = false,
-  } = props
-  const [emblaRef, emblaApi] = useEmblaCarousel(options)
-  const [selectedIndex, setSelectedIndex] = useState(0)
-  const [scrollSnaps, setScrollSnaps] = useState<number[]>([])
-  const [prevBtnEnabled, setPrevBtnEnabled] = useState(false)
-  const [nextBtnEnabled, setNextBtnEnabled] = useState(false)
+const EmblaCarousel = lazy(() =>
+  import('./EmblaCarousel').then(module => ({
+    default: module.EmblaCarousel,
+  }))
+)
 
-  const scrollPrev = useCallback(() => emblaApi && emblaApi.scrollPrev(), [emblaApi])
-  const scrollNext = useCallback(() => emblaApi && emblaApi.scrollNext(), [emblaApi])
-  const scrollTo = useCallback((index: number) => emblaApi && emblaApi.scrollTo(index), [emblaApi])
-
-  const onInit = useCallback(() => {
-    if (!emblaApi) {
-      return
-    }
-    setScrollSnaps(emblaApi.scrollSnapList())
-  }, [emblaApi])
-
-  const onSelect = useCallback(() => {
-    if (!emblaApi) {
-      return
-    }
-
-    const index = emblaApi.selectedScrollSnap()
-
-    if (onSlideChange) {
-      onSlideChange(index)
-    }
-
-    setSelectedIndex(emblaApi.selectedScrollSnap())
-    setPrevBtnEnabled(emblaApi.canScrollPrev())
-    setNextBtnEnabled(emblaApi.canScrollNext())
-  }, [emblaApi, onSlideChange])
-
-  useEffect(() => {
-    if (!emblaApi) {
-      return
-    }
-    onInit()
-    onSelect()
-    emblaApi.on('reInit', onInit)
-    emblaApi.on('reInit', onSelect)
-    emblaApi.on('select', onSelect)
-
-    return () => {
-      emblaApi.off('reInit', onInit)
-      emblaApi.off('reInit', onSelect)
-      emblaApi.off('select', onSelect)
-    }
-  }, [emblaApi, onInit, onSelect])
+const CarouselSingleSlide = ({
+  slides,
+  filtersState,
+  imageSizes,
+  priorityFirstImage,
+}: Required<Pick<CarouselProps, 'slides' | 'imageSizes' | 'priorityFirstImage'>> &
+  Pick<CarouselProps, 'filtersState'>) => {
+  const singleSlide = slides[0]
+  const filter = filtersState?.[0] ?? ''
+  const imageLoadingStrategy = priorityFirstImage
+    ? IMAGE_LOADING_STRATEGY.lcp
+    : IMAGE_LOADING_STRATEGY.default
 
   return (
     <div className={s.carousel}>
-      <div className={s.carousel__viewport} ref={emblaRef}>
+      <div className={s.carousel__viewport}>
         <div className={s.carousel__container}>
-          {slides.map((slide, index) => {
-            const filter = filtersState && filtersState[index] ? filtersState[index] : ''
-            const imageLoadingStrategy =
-              priorityFirstImage && index === 0
-                ? IMAGE_LOADING_STRATEGY.lcp
-                : IMAGE_LOADING_STRATEGY.default
-
-            return (
-              <div className={s.carousel__slide} key={index}>
-                <div className={s.carousel__image}>
-                  <Image
-                    {...imageLoadingStrategy}
-                    src={typeof slide === 'string' ? slide : slide.url}
-                    alt={`Image ${index + 1}`}
-                    fill
-                    sizes={imageSizes}
-                    className={filter ? s[filter.toLowerCase()] : ''}
-                  />
-                </div>
-              </div>
-            )
-          })}
-        </div>
-      </div>
-
-      {slides.length > 1 && (
-        <div className={s.carousel__nav}>
-          <button
-            className={s.carousel__button}
-            onClick={scrollPrev}
-            disabled={!prevBtnEnabled}
-            type={'button'}
-            aria-label={'Previous slide'}
-          >
-            <ArrowBackSimple />
-          </button>
-          <button
-            className={s.carousel__button}
-            onClick={scrollNext}
-            disabled={!nextBtnEnabled}
-            type={'button'}
-            aria-label={'Next slide'}
-          >
-            <ArrowForwardSimple />
-          </button>
-        </div>
-      )}
-
-      {slides.length > 1 && (
-        <div className={s.carousel__controls}>
-          <div className={s.carousel__dots}>
-            {scrollSnaps.map((_, index) => (
-              <button
-                key={index}
-                className={`${s.carousel__dot} ${index === selectedIndex ? s['carousel__dot--active'] : ''}`}
-                type={'button'}
-                onClick={() => scrollTo(index)}
-                aria-label={`Go to slide ${index + 1}`}
+          <div className={s.carousel__slide}>
+            <div className={s.carousel__image}>
+              <Image
+                {...imageLoadingStrategy}
+                src={typeof singleSlide === 'string' ? singleSlide : singleSlide.url}
+                alt={'Image 1'}
+                fill
+                sizes={imageSizes}
+                className={filter ? s[filter.toLowerCase()] : ''}
               />
-            ))}
+            </div>
           </div>
         </div>
-      )}
+      </div>
     </div>
+  )
+}
+
+export const Carousel: FC<CarouselProps> = ({
+  slides,
+  options,
+  filtersState,
+  onSlideChange,
+  imageSizes = IMAGE_SIZES.PUBLIC_POST,
+  priorityFirstImage = false,
+}) => {
+  if (slides.length === 0) {
+    return null
+  }
+
+  if (slides.length === 1) {
+    return (
+      <CarouselSingleSlide
+        slides={slides}
+        filtersState={filtersState}
+        imageSizes={imageSizes}
+        priorityFirstImage={priorityFirstImage}
+      />
+    )
+  }
+
+  return (
+    <Suspense
+      fallback={
+        <CarouselSingleSlide
+          slides={slides}
+          filtersState={filtersState}
+          imageSizes={imageSizes}
+          priorityFirstImage={priorityFirstImage}
+        />
+      }
+    >
+      <EmblaCarousel
+        slides={slides}
+        options={options}
+        filtersState={filtersState}
+        onSlideChange={onSlideChange}
+        imageSizes={imageSizes}
+        priorityFirstImage={priorityFirstImage}
+      />
+    </Suspense>
   )
 }

--- a/src/shared/composites/Carousel/EmblaCarousel.tsx
+++ b/src/shared/composites/Carousel/EmblaCarousel.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { UserImage } from '@/entities/users/api/api.types'
+import { IMAGE_LOADING_STRATEGY } from '@/shared/constant'
+import { ArrowBackSimple, ArrowForwardSimple } from '@/shared/ui'
+import useEmblaCarousel from 'embla-carousel-react'
+import Image from 'next/image'
+
+import s from './Carousel.module.scss'
+
+export type EmblaOptionsType = Parameters<typeof useEmblaCarousel>[0]
+
+type EmblaCarouselProps = {
+  slides: UserImage[] | string[]
+  options?: EmblaOptionsType
+  filtersState?: Record<number, string>
+  onSlideChange?: (index: number) => void
+  imageSizes: string
+  priorityFirstImage: boolean
+}
+
+export const EmblaCarousel = ({
+  slides,
+  options,
+  filtersState,
+  onSlideChange,
+  imageSizes,
+  priorityFirstImage,
+}: EmblaCarouselProps) => {
+  const [emblaRef, emblaApi] = useEmblaCarousel(options)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [scrollSnaps, setScrollSnaps] = useState<number[]>([])
+  const [prevBtnEnabled, setPrevBtnEnabled] = useState(false)
+  const [nextBtnEnabled, setNextBtnEnabled] = useState(false)
+
+  const scrollPrev = useCallback(() => emblaApi && emblaApi.scrollPrev(), [emblaApi])
+  const scrollNext = useCallback(() => emblaApi && emblaApi.scrollNext(), [emblaApi])
+  const scrollTo = useCallback((index: number) => emblaApi && emblaApi.scrollTo(index), [emblaApi])
+
+  const onInit = useCallback(() => {
+    if (!emblaApi) {
+      return
+    }
+    setScrollSnaps(emblaApi.scrollSnapList())
+  }, [emblaApi])
+
+  const onSelect = useCallback(() => {
+    if (!emblaApi) {
+      return
+    }
+
+    const index = emblaApi.selectedScrollSnap()
+
+    if (onSlideChange) {
+      onSlideChange(index)
+    }
+
+    setSelectedIndex(index)
+    setPrevBtnEnabled(emblaApi.canScrollPrev())
+    setNextBtnEnabled(emblaApi.canScrollNext())
+  }, [emblaApi, onSlideChange])
+
+  useEffect(() => {
+    if (!emblaApi) {
+      return
+    }
+    onInit()
+    onSelect()
+    emblaApi.on('reInit', onInit)
+    emblaApi.on('reInit', onSelect)
+    emblaApi.on('select', onSelect)
+
+    return () => {
+      emblaApi.off('reInit', onInit)
+      emblaApi.off('reInit', onSelect)
+      emblaApi.off('select', onSelect)
+    }
+  }, [emblaApi, onInit, onSelect])
+
+  return (
+    <div className={s.carousel}>
+      <div className={s.carousel__viewport} ref={emblaRef}>
+        <div className={s.carousel__container}>
+          {slides.map((slide, index) => {
+            const filter = filtersState && filtersState[index] ? filtersState[index] : ''
+            const imageLoadingStrategy =
+              priorityFirstImage && index === 0
+                ? IMAGE_LOADING_STRATEGY.lcp
+                : IMAGE_LOADING_STRATEGY.default
+
+            return (
+              <div className={s.carousel__slide} key={index}>
+                <div className={s.carousel__image}>
+                  <Image
+                    {...imageLoadingStrategy}
+                    src={typeof slide === 'string' ? slide : slide.url}
+                    alt={`Image ${index + 1}`}
+                    fill
+                    sizes={imageSizes}
+                    className={filter ? s[filter.toLowerCase()] : ''}
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className={s.carousel__nav}>
+        <button
+          className={s.carousel__button}
+          onClick={scrollPrev}
+          disabled={!prevBtnEnabled}
+          type={'button'}
+          aria-label={'Previous slide'}
+        >
+          <ArrowBackSimple />
+        </button>
+        <button
+          className={s.carousel__button}
+          onClick={scrollNext}
+          disabled={!nextBtnEnabled}
+          type={'button'}
+          aria-label={'Next slide'}
+        >
+          <ArrowForwardSimple />
+        </button>
+      </div>
+
+      <div className={s.carousel__controls}>
+        <div className={s.carousel__dots}>
+          {scrollSnaps.map((_, index) => (
+            <button
+              key={index}
+              className={`${s.carousel__dot} ${index === selectedIndex ? s['carousel__dot--active'] : ''}`}
+              type={'button'}
+              onClick={() => scrollTo(index)}
+              aria-label={`Go to slide ${index + 1}`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/widgets/Header/components/HeaderControls/HeaderControls.tsx
+++ b/src/widgets/Header/components/HeaderControls/HeaderControls.tsx
@@ -1,6 +1,8 @@
 'use client'
 import { useAuthUiState } from '@/features/posts/utils/useAuthUiState'
-import { AuthBtn, LanguageSelect, NotificationButton } from '@/widgets/Header/components'
+import { AuthBtn } from '@/widgets/Header/components/AuthBtn'
+import { LanguageSelect } from '@/widgets/Header/components/LanguageSelect'
+import { NotificationButton } from '@/widgets/Header/components/NotificationButton'
 
 import { HeaderSkeleton } from './HeaderSkeleton'
 

--- a/src/widgets/Header/index.tsx
+++ b/src/widgets/Header/index.tsx
@@ -17,7 +17,7 @@ export const AppHeader = (): ReactElement => {
   return (
     <Header className={s.header}>
       <div className={s.header__container}>
-        <Link href={APP_ROUTES.ROOT}>
+        <Link href={APP_ROUTES.ROOT} prefetch={false}>
           <Typography variant={'h1'}>ICTRoot</Typography>
         </Link>
         <div className={s.header__controls}>

--- a/src/widgets/Header/index.tsx
+++ b/src/widgets/Header/index.tsx
@@ -1,12 +1,17 @@
 'use client'
-import { ReactElement } from 'react'
+import { lazy, ReactElement, Suspense } from 'react'
 
 import { APP_ROUTES } from '@/shared/constant'
 import { Header, Typography } from '@/shared/ui'
-import { HeaderControls } from '@/widgets/Header/components/HeaderControls/HeaderControls'
 import Link from 'next/link'
 
 import s from './AppHeader.module.scss'
+
+const HeaderControls = lazy(() =>
+  import('@/widgets/Header/components/HeaderControls/HeaderControls').then(module => ({
+    default: module.HeaderControls,
+  }))
+)
 
 export const AppHeader = (): ReactElement => {
   return (
@@ -16,7 +21,9 @@ export const AppHeader = (): ReactElement => {
           <Typography variant={'h1'}>ICTRoot</Typography>
         </Link>
         <div className={s.header__controls}>
-          <HeaderControls />
+          <Suspense fallback={null}>
+            <HeaderControls />
+          </Suspense>
         </div>
       </div>
     </Header>


### PR DESCRIPTION
## Summary

- Jira: SCRUM-152
- What changed:
- Added route/auth-based code splitting for:
- `src/app/RootLayoutClient.tsx` (`Sidebar`, `CreatePostWrapper`)
- `src/widgets/Header/index.tsx` (lazy loading `HeaderControls`)
- `src/widgets/Header/components/HeaderControls/HeaderControls.tsx` (direct imports for auth-controls)
- Refactored carousel loading:
- `src/shared/composites/Carousel/Carousel.tsx`
- `src/shared/composites/Carousel/EmblaCarousel.tsx` (new)
- Embla is loaded only when `images.length > 1`.
- Follow-up stability fix: disabled home prefetch from header logo to avoid background proxy `ECONNRESET` noise on profile page.

## Scope

### In scope

- Route/Auth-based code splitting for sidebar/create-post/header auth-controls
- Carousel optimization for multi-image only
- Related prefetch fix in header logo link

### Out of scope

- Changes in `.ai/**`, `scripts/**`, `tests/**`, `output/**`
- Infra/governance updates unrelated to SCRUM-152

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

If architectural change is checked:

- add label `policy-change`
- fill `Contract change` section
- update `.ai/policy.md` version metadata

## Contract change

- What changed: N/A
- Why: N/A
- Impact/Migration: N/A
- Policy version updated: N/A

## Mandatory checklist

- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
- `pnpm run ci:check` — PASS
- Includes lint/typecheck/contract checks/contracts tests/build
- Existing warnings remain unchanged; no new errors introduced

### Manual

- Scenario 1:
- Open `/` as guest:
- Header renders correctly
- Auth controls work
- No regressions in public feed rendering
- Scenario 2:
- Open authenticated flow (`/create`, modal flow from sidebar):
- Sidebar and create-post flow load and work correctly after lazy split
- Scenario 3:
- Posts with 1 image:
- Carousel fallback renders single image without Embla controls
- Scenario 4:
- Posts with >1 images:
- Embla carousel loads and navigation/dots work
- Scenario 5:
- Open `/profile/[id]`:
- No background prefetch-triggered proxy noise from header logo link

## Risks and Rollback

- Risks:
- Slight first-interaction delay for lazily loaded header/sidebar/create-post controls on cold cache
- Rollback plan:
- Revert commits:
- `b15570c` (header prefetch fix)
- `84f4327` (main SCRUM-152 implementation)
