### PR TITLE
Scrum 205 t0 pricing api integration and remove hardcoded prices

### DIFF
--- a/src/app/profile/[id]/settings/[tab]/page.tsx
+++ b/src/app/profile/[id]/settings/[tab]/page.tsx
@@ -1,11 +1,11 @@
-import { AccountManagement, Devices, GeneralInfo } from '@/features/profile/settings'
+import { Devices, GeneralInfo, Payments } from '@/features/profile/settings'
 import { SubscriptionPricing } from '@/features/subscriptions'
 
 const TABS = {
   general: GeneralInfo,
   devices: Devices,
-  account: AccountManagement,
-  payments: SubscriptionPricing,
+  account: SubscriptionPricing,
+  payments: Payments,
 } as const
 
 type TabKey = keyof typeof TABS

--- a/src/app/profile/[id]/settings/[tab]/page.tsx
+++ b/src/app/profile/[id]/settings/[tab]/page.tsx
@@ -1,10 +1,9 @@
-import { Devices, GeneralInfo, Payments } from '@/features/profile/settings'
-import { SubscriptionPricing } from '@/features/subscriptions'
+import { AccountManagement, Devices, GeneralInfo, Payments } from '@/features/profile/settings'
 
 const TABS = {
   general: GeneralInfo,
   devices: Devices,
-  account: SubscriptionPricing,
+  account: AccountManagement,
   payments: Payments,
 } as const
 

--- a/src/app/profile/[id]/settings/[tab]/page.tsx
+++ b/src/app/profile/[id]/settings/[tab]/page.tsx
@@ -1,10 +1,11 @@
-import { AccountManagement, Devices, GeneralInfo, Payments } from '@/features/profile/settings'
+import { AccountManagement, Devices, GeneralInfo } from '@/features/profile/settings'
+import { SubscriptionPricing } from '@/features/subscriptions'
 
 const TABS = {
   general: GeneralInfo,
   devices: Devices,
   account: AccountManagement,
-  payments: Payments,
+  payments: SubscriptionPricing,
 } as const
 
 type TabKey = keyof typeof TABS

--- a/src/features/profile/settings/ui/AccountManagement.tsx
+++ b/src/features/profile/settings/ui/AccountManagement.tsx
@@ -1,3 +1,6 @@
+import { SubscriptionPricing } from '@/features/subscriptions'
+
 export function AccountManagement() {
-  return <div>Account management for user </div>
+  // Account tab only: pricing preview belongs to Account Management, not to My Payments.
+  return <SubscriptionPricing />
 }

--- a/src/features/subscriptions/index.ts
+++ b/src/features/subscriptions/index.ts
@@ -1,2 +1,3 @@
 export * from './api'
 export * from './model'
+export * from './ui'

--- a/src/features/subscriptions/ui/SubscriptionPricing.module.scss
+++ b/src/features/subscriptions/ui/SubscriptionPricing.module.scss
@@ -4,24 +4,65 @@
   width: 100%;
 }
 
-.grid {
+.noticeCard {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-}
-
-.card {
-  display: grid;
-  gap: 8px;
+  gap: 6px;
   padding: 16px;
 }
 
-.amount {
-  color: var(--color-primary-500);
+.noticeTitle {
+  color: var(--color-light-100);
 }
 
-.hint {
+.noticeText {
   color: var(--color-light-900);
+}
+
+.pricingCard {
+  padding: 0;
+}
+
+.pricingList {
+  display: grid;
+}
+
+.planRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 56px;
+  padding: 14px 16px;
+  border-top: 1px solid var(--color-dark-100);
+}
+
+.planRow:first-child {
+  border-top: 0;
+}
+
+.pseudoRadio,
+.pseudoRadioSelected {
+  flex-shrink: 0;
+  display: block;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--color-light-100);
+  border-radius: 50%;
+}
+
+.pseudoRadioSelected {
+  position: relative;
+}
+
+.pseudoRadioSelected::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  background-color: var(--color-light-100);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .stateCard {
@@ -36,9 +77,4 @@
 
 .retryButton {
   width: fit-content;
-}
-
-.loadingState {
-  min-height: 44px;
-  position: relative;
 }

--- a/src/features/subscriptions/ui/SubscriptionPricing.module.scss
+++ b/src/features/subscriptions/ui/SubscriptionPricing.module.scss
@@ -1,0 +1,44 @@
+.root {
+  display: grid;
+  gap: 16px;
+  width: 100%;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+}
+
+.amount {
+  color: var(--color-primary-500);
+}
+
+.hint {
+  color: var(--color-light-900);
+}
+
+.stateCard {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.stateText {
+  color: var(--color-light-900);
+}
+
+.retryButton {
+  width: fit-content;
+}
+
+.loadingState {
+  min-height: 44px;
+  position: relative;
+}

--- a/src/features/subscriptions/ui/SubscriptionPricing.tsx
+++ b/src/features/subscriptions/ui/SubscriptionPricing.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react'
 
 import { useGetPricingQuery } from '@/features/subscriptions/api'
 import { mapSubscriptionTypeToLabel } from '@/features/subscriptions/model'
-import { Loading } from '@/shared/composites'
 import { SubscriptionType } from '@/shared/types'
 import { Button, Card, Typography } from '@/shared/ui'
 
@@ -17,11 +16,11 @@ const SUBSCRIPTION_ORDER: Record<SubscriptionType, number> = {
 }
 
 export function SubscriptionPricing() {
-  const { data, isError, isLoading, refetch } = useGetPricingQuery()
+  const { data, isError, refetch } = useGetPricingQuery()
 
   const pricingPlans = useMemo(() => {
     if (!data) {
-      return null
+      return []
     }
 
     return [...data.data].sort(
@@ -29,17 +28,6 @@ export function SubscriptionPricing() {
         SUBSCRIPTION_ORDER[left.typeDescription] - SUBSCRIPTION_ORDER[right.typeDescription]
     )
   }, [data])
-
-  if (isLoading) {
-    return (
-      <Card className={styles.stateCard}>
-        <div className={styles.loadingState}>
-          <Loading size={8} />
-        </div>
-        <Typography variant={'regular_16'}>Loading pricing...</Typography>
-      </Card>
-    )
-  }
 
   if (isError) {
     return (
@@ -55,7 +43,11 @@ export function SubscriptionPricing() {
     )
   }
 
-  if (!pricingPlans || !pricingPlans.length) {
+  if (!data) {
+    return null
+  }
+
+  if (!pricingPlans.length) {
     return (
       <Card className={styles.stateCard}>
         <Typography variant={'h3'}>No pricing plans</Typography>
@@ -68,22 +60,34 @@ export function SubscriptionPricing() {
 
   return (
     <div className={styles.root}>
-      <Typography variant={'h3'}>Subscription plans</Typography>
-      <div className={styles.grid}>
-        {pricingPlans.map(plan => (
-          <Card key={plan.typeDescription} className={styles.card}>
-            <Typography variant={'regular_16'}>
-              {mapSubscriptionTypeToLabel(plan.typeDescription)}
-            </Typography>
-            <Typography className={styles.amount} variant={'h2'}>
-              {plan.amount}
-            </Typography>
-            <Typography className={styles.hint} variant={'small_text'}>
-              API pricing
-            </Typography>
-          </Card>
-        ))}
-      </div>
+      <Typography variant={'h3'}>Change your subscription:</Typography>
+      <Card className={styles.noticeCard}>
+        <Typography className={styles.noticeTitle} variant={'regular_16'}>
+          Temporary pricing preview
+        </Typography>
+        <Typography className={styles.noticeText} variant={'small_text'}>
+          Plans below are rendered from `useGetPricingQuery`.
+        </Typography>
+        <Typography className={styles.noticeText} variant={'small_text'}>
+          Next step for Account Management flow (T2+): connect selected plan with
+          `createSubscription` and subscription state from `getCurrentSubscription`.
+        </Typography>
+      </Card>
+      <Card className={styles.pricingCard}>
+        <div className={styles.pricingList}>
+          {pricingPlans.map((plan, index) => (
+            <div key={plan.typeDescription} className={styles.planRow}>
+              <span
+                aria-hidden
+                className={index === 0 ? styles.pseudoRadioSelected : styles.pseudoRadio}
+              />
+              <Typography variant={'regular_16'}>
+                ${plan.amount} per {mapSubscriptionTypeToLabel(plan.typeDescription)}
+              </Typography>
+            </div>
+          ))}
+        </div>
+      </Card>
     </div>
   )
 }

--- a/src/features/subscriptions/ui/SubscriptionPricing.tsx
+++ b/src/features/subscriptions/ui/SubscriptionPricing.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { useGetPricingQuery } from '@/features/subscriptions/api'
+import { mapSubscriptionTypeToLabel } from '@/features/subscriptions/model'
+import { Loading } from '@/shared/composites'
+import { SubscriptionType } from '@/shared/types'
+import { Button, Card, Typography } from '@/shared/ui'
+
+import styles from './SubscriptionPricing.module.scss'
+
+const SUBSCRIPTION_ORDER: Record<SubscriptionType, number> = {
+  [SubscriptionType.DAY]: 0,
+  [SubscriptionType.WEEKLY]: 1,
+  [SubscriptionType.MONTHLY]: 2,
+}
+
+export function SubscriptionPricing() {
+  const { data, isError, isLoading, refetch } = useGetPricingQuery()
+
+  const pricingPlans = useMemo(() => {
+    if (!data) {
+      return null
+    }
+
+    return [...data.data].sort(
+      (left, right) =>
+        SUBSCRIPTION_ORDER[left.typeDescription] - SUBSCRIPTION_ORDER[right.typeDescription]
+    )
+  }, [data])
+
+  if (isLoading) {
+    return (
+      <Card className={styles.stateCard}>
+        <div className={styles.loadingState}>
+          <Loading size={8} />
+        </div>
+        <Typography variant={'regular_16'}>Loading pricing...</Typography>
+      </Card>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Card className={styles.stateCard}>
+        <Typography variant={'h3'}>Could not load pricing</Typography>
+        <Typography className={styles.stateText} variant={'regular_16'}>
+          Please try again.
+        </Typography>
+        <Button className={styles.retryButton} variant={'outlined'} onClick={() => refetch()}>
+          Retry
+        </Button>
+      </Card>
+    )
+  }
+
+  if (!pricingPlans || !pricingPlans.length) {
+    return (
+      <Card className={styles.stateCard}>
+        <Typography variant={'h3'}>No pricing plans</Typography>
+        <Typography className={styles.stateText} variant={'regular_16'}>
+          Pricing is currently unavailable.
+        </Typography>
+      </Card>
+    )
+  }
+
+  return (
+    <div className={styles.root}>
+      <Typography variant={'h3'}>Subscription plans</Typography>
+      <div className={styles.grid}>
+        {pricingPlans.map(plan => (
+          <Card key={plan.typeDescription} className={styles.card}>
+            <Typography variant={'regular_16'}>
+              {mapSubscriptionTypeToLabel(plan.typeDescription)}
+            </Typography>
+            <Typography className={styles.amount} variant={'h2'}>
+              {plan.amount}
+            </Typography>
+            <Typography className={styles.hint} variant={'small_text'}>
+              API pricing
+            </Typography>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/features/subscriptions/ui/SubscriptionPricing.tsx
+++ b/src/features/subscriptions/ui/SubscriptionPricing.tsx
@@ -44,6 +44,7 @@ export function SubscriptionPricing() {
   }
 
   if (!data) {
+    // Global settings-tabs loading already covers this state, so no local pricing loader here.
     return null
   }
 
@@ -60,6 +61,8 @@ export function SubscriptionPricing() {
 
   return (
     <div className={styles.root}>
+      {/* TODO(SCRUM-199, T2/T3/T4): replace preview with final Account Management composition
+          and bind selected plan to payment flow (createSubscription + return/polling). */}
       <Typography variant={'h3'}>Change your subscription:</Typography>
       <Card className={styles.noticeCard}>
         <Typography className={styles.noticeTitle} variant={'regular_16'}>

--- a/src/features/subscriptions/ui/index.ts
+++ b/src/features/subscriptions/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './SubscriptionPricing'


### PR DESCRIPTION
## Summary

- Jira: `SCRUM-205`
- What changed:
- Подключен и доработан pricing-блок для `Account Management` на базе API (`useGetPricingQuery`).
- Исправлено соответствие вкладок settings: `account -> SubscriptionPricing`, `payments -> Payments`.
- Убрано локальное loading-состояние внутри pricing-блока (оставлены `error/empty/success`).
- Добавлен временный handoff-блок (пояснение для следующих задач T2+).
- Визуал pricing переделан в псевдо-список, ближе к дизайну, с реальными данными из backend.

## Scope

### In scope

- Изменения только в payments scope (T0/T1 UI-уточнение).
- Файлы:
- `src/app/profile/[id]/settings/[tab]/page.tsx`
- `src/features/subscriptions/ui/SubscriptionPricing.tsx`
- `src/features/subscriptions/ui/SubscriptionPricing.module.scss`

### Out of scope

- `T2+` flow (redirect/polling/idempotency/modals/auto-renew orchestration/my-payments logic).
- Неплатежные изменения и process/docs-файлы.

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

## Contract change

- What changed: `N/A`
- Why: `N/A`
- Impact/Migration: `N/A`
- Policy version updated: `N/A`

## Mandatory checklist

- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
- `pnpm run ci:check` — passed (имеются только pre-existing warnings вне scope PR).

### Manual

- Scenario 1: `/profile/[id]/settings/account` — pricing отображается в `Account Management`, а не в `My payments`.
- Scenario 2: При успешном ответе API тарифы рендерятся из backend (`amount + subscription type`), без локального хардкода.
- Scenario 3: При ошибке API отображается error-state + `Retry`.
- Scenario 4: При пустом `data` отображается empty-state.
- Scenario 5: При переходе между вкладками нет локального loader внутри pricing-блока.

## Risks and Rollback

- Risks:
- Временный handoff-блок может остаться дольше планируемого срока, если не удалить в T3/T4.
- Псевдо-UI списка тарифов может частично отличаться от финальной Figma-реализации (ожидаемо для текущего этапа).
- Rollback plan:
- `git revert bc43c94` (или откат PR целиком), затем повторная проверка `pnpm run ci:check`.
