### PR TITLE
Fix/icons reexport prerender

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,31 @@
+name: Unit Tests (Vitest)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm run test:run

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/docs/analysis/06-sprint6-msw-testing-playbook.md
+++ b/docs/analysis/06-sprint6-msw-testing-playbook.md
@@ -1,0 +1,210 @@
+# Sprint 6: MSW Playbook (По Задачам И Разработчикам)
+
+Документ для Sprint 6 (`T0..T7`) о том, где и как использовать `MSW` в тестах.
+В чате иногда звучало `MCV`/`mcv` — в проекте используем именно `MSW` (`Mock Service Worker`).
+
+## 1. Цель
+
+- Снизить флаки в PR/CI (меньше зависимости от сети и состояния backend).
+- Ускорить ревью (детерминированные тесты для API-сценариев).
+- Разделить ответственность:
+  - runtime приложения -> реальный API;
+  - unit/integration tests -> MSW;
+  - финальный smoke/e2e (`T7`) -> реальный API.
+
+## 2. Что Уже Сделано (База Готова)
+
+Эти шаги повторять не нужно, они уже в репозитории:
+
+- MSW dependency подключена (`package.json`).
+- Vitest setup подключен:
+  - `vitest.config.mts`
+  - `vitest.setup.ts`
+- Базовая структура для команды:
+  - `src/test/msw/handlers/subscriptions.handlers.ts`
+  - `src/test/msw/server.ts`
+  - `src/test/msw/index.ts`
+- Автозапуск тестов в CI:
+  - `.github/workflows/unit-tests.yml`
+
+## 3. REAL EXAMPLES vs TEMPLATE
+
+### REAL EXAMPLES (уже реализовано и запускается)
+
+Файл: `src/features/subscriptions/api/subscriptionsApi.msw.test.ts`
+
+- `getPricing` через MSW handler (`T0/T1` read-flow).
+- `getCurrentSubscription` через MSW handler (`T0/T1` read-flow).
+- `createSubscription` error path `409` через MSW handler (T2-related пример для error matrix).
+
+### TEMPLATE (направление, не "сделано за разработчика")
+
+- `T2` polling/timeout/stop-rules.
+- `T3/T4` view-state tests (`Personal/BusinessNoSubscription/BusinessActiveSubscription`).
+- `T5` table sorting/pageSize/pagination.
+- `T6` modal orchestration branches.
+
+## 4. Матрица: Где MSW Обязателен
+
+| Разработчик | Задачи по плану                   | MSW статус                                                                    | Что покрываем                                                                                                          |
+| ----------- | --------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Sem         | `T0`, `T1` (+ support `T2`, `T4`) | Для уже закрытых `T0/T1` ретрофит опционален. Для новых тестов — использовать | `getPricing`, `getCurrentSubscription`, `getPayments`, базовые handlers инфраструктуры                                 |
+| Timofey     | `T2`, `T6`                        | Обязательно                                                                   | return flow, polling, error matrix (`400/401/404/409`), idempotency сценарии                                           |
+| Evgeniy     | `T3`, `T4` (+ support `T5`)       | Обязательно                                                                   | container/view-state на данных API (`Personal/BusinessNoSubscription/BusinessActiveSubscription`), auto-renew сценарии |
+| Dmitriy     | `T5`, `T6`                        | Обязательно                                                                   | my payments table (sorting/pageSize/pagination), modal branches                                                        |
+
+## 5. Что Должны Сделать Разработчики Сейчас
+
+### Timofey (`T2`, `T6`)
+
+- Добавить MSW-based integration tests на:
+  - return flow без `status` query;
+  - polling (`3s/90s`, success/timeout/stop);
+  - idempotency lock;
+  - errors `400/401/404/409`.
+
+### Evgeniy (`T3`, `T4`)
+
+- Добавить:
+  - resolver unit tests (без MSW);
+  - MSW integration test для container/view-state на API данных;
+  - auto-renew сценарии (`on/off`) в `T4`.
+
+### Dmitriy (`T5`, `T6`)
+
+- Добавить MSW-based integration tests на:
+  - сортировку/пагинацию/pageSize;
+  - reset `page=1` при смене `sort/pageSize`;
+  - modal branches для `T6`.
+
+## 6. TEMPLATE Сниппеты Для Команды (Ориентир, Не Готовый Тест)
+
+Ниже именно шаблоны направления. Их нужно адаптировать под код своей ветки.
+
+Важно:
+
+- это не "реализовано за задачу";
+- это не acceptance criteria;
+- каждый snippet нужно адаптировать под реальные компоненты/селекторы/хуки своей ветки.
+
+### T2 (`TEMPLATE`) polling success
+
+```ts
+let call = 0
+server.use(
+  http.get('*/subscriptions/current-payment-subscriptions', () => {
+    call += 1
+    return HttpResponse.json(
+      call < 2
+        ? { data: [{ subscriptionId: 'old' }], hasAutoRenewal: true }
+        : { data: [{ subscriptionId: 'old' }, { subscriptionId: 'new' }], hasAutoRenewal: true }
+    )
+  })
+)
+```
+
+### T3/T4 (`TEMPLATE`) business без активной подписки
+
+```ts
+server.use(
+  http.get('*/subscriptions/current-payment-subscriptions', () =>
+    HttpResponse.json({ data: [], hasAutoRenewal: false })
+  )
+)
+
+renderWithStore(<AccountManagementPage accountType="business" />)
+expect(await screen.findByText(/Change your subscription/i)).toBeInTheDocument()
+```
+
+### T5 (`TEMPLATE`) query params таблицы платежей
+
+```ts
+server.use(
+  http.get('*/subscriptions/my-payments', ({ request }) => {
+    const url = new URL(request.url)
+    expect(url.searchParams.get('sortBy')).toBe('price')
+    expect(url.searchParams.get('sortDirection')).toBe('asc')
+    expect(url.searchParams.get('pageSize')).toBe('25')
+    return HttpResponse.json({ totalCount: 0, pagesCount: 0, page: 1, pageSize: 25, items: [] })
+  })
+)
+```
+
+### T6 (`TEMPLATE`) error ветка модалки
+
+```ts
+server.use(
+  http.post('*/subscriptions', () =>
+    HttpResponse.json({ message: 'Subscription conflict' }, { status: 409 })
+  )
+)
+
+await userEvent.click(screen.getByRole('button', { name: /pay/i }))
+expect(await screen.findByText(/Transaction failed/i)).toBeInTheDocument()
+```
+
+## 7. Обязательные Тесты По Задачам (MUST)
+
+| Задача                                 | Что обязательно проверить тестами                                                                      |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `T2.1` Return detector + query cleanup | return без `status` query запускает flow; query очищается после обработки                              |
+| `T2.2` Polling engine                  | интервал `3s`, timeout `90s`, success по новой/измененной подписке, корректный `stop`                  |
+| `T2.3` Idempotency guard               | повторный клик блокируется; при polling кнопки lock; нет автозапуска `createSubscription` после return |
+| `T2.4` Payment orchestration           | `create -> redirect -> return` ветки + проброс `400/401/404/409`                                       |
+| `T3` Container + views + resolver      | все ветки resolver (`Personal`, `BusinessNoSubscription`, `BusinessActiveSubscription`)                |
+| `T4` Current subscription + auto-renew | toggle auto-renew + корректная очередь подписок (`UC-3`)                                               |
+| `T5` My payments table                 | sorting, pagination, pageSize, reset `page=1` при смене `sort/pageSize`                                |
+| `T6` Modals                            | `PayPal warning`, `Confirm`, `Success`, `Error`, disabled `OK` без `I agree`                           |
+
+## 8. Правило Для Sprint 6
+
+- Если задача трогает API-поток и UI-ветвления (`T2/T3/T4/T5/T6`) -> добавляем хотя бы 1 MSW-based integration test в PR.
+- Для чистых функций (`resolver`, `mapper`) -> unit-тесты без MSW.
+- Для `T7` -> итоговый smoke на реальном API обязателен.
+
+## 9. Структура Test-Файлов (Важно)
+
+- `subscriptionsApi.msw.test.ts` — только API-level тесты `features/subscriptions/api`.
+- Не складываем все сценарии спринта в один файл.
+- Каждый владелец задачи пишет тесты рядом со своим модулем:
+  - `T2` -> тесты polling/return/idempotency в `T2` модуле;
+  - `T3/T4` -> container/view-state/resolver tests рядом с account-management/subscriptions UI/model;
+  - `T5` -> table sorting/pagination/pageSize tests рядом с My Payments;
+  - `T6` -> modal/wiring tests рядом с модалками/flow.
+- Общими остаются только bootstrap-части:
+  - `src/test/msw/*` (server + handlers),
+  - общие test helpers (если добавятся отдельно).
+
+### 9.1 Рекомендованные Пути По Задачам (Для Команды)
+
+Ниже target-пути для Sprint 6. Если папка еще не создана в вашей ветке, создаем ее при реализации задачи.
+
+- Timofey (`T2`):
+  - `src/features/subscriptions/model/__tests__/subscriptionReturnFlow.test.ts`
+  - `src/features/subscriptions/model/__tests__/subscriptionPolling.test.ts`
+  - `src/features/subscriptions/model/__tests__/subscriptionIdempotency.test.ts`
+  - `src/features/subscriptions/ui/__tests__/subscriptionPaymentFlow.test.tsx`
+- Evgeniy (`T3`, `T4`):
+  - `src/features/subscriptions/model/__tests__/resolveAccountManagementView.test.ts`
+  - `src/features/subscriptions/ui/__tests__/AccountManagementPage.test.tsx`
+  - `src/features/subscriptions/ui/__tests__/PersonalView.test.tsx`
+  - `src/features/subscriptions/ui/__tests__/BusinessNoSubscriptionView.test.tsx`
+  - `src/features/subscriptions/ui/__tests__/BusinessActiveSubscriptionView.test.tsx`
+  - `src/features/subscriptions/ui/__tests__/AutoRenewalToggle.test.tsx`
+- Dmitriy (`T5`, `T6`):
+  - `src/features/subscriptions/ui/__tests__/MyPaymentsTable.test.tsx`
+  - `src/features/subscriptions/ui/__tests__/MyPaymentsPagination.test.tsx`
+  - `src/features/subscriptions/ui/__tests__/SubscriptionModalsFlow.test.tsx`
+- Общий API-level (оставляем отдельно):
+  - `src/features/subscriptions/api/subscriptionsApi.msw.test.ts`
+
+## 10. Что Писать В PR (Короткий Шаблон)
+
+- Какие handlers добавлены.
+- Какой сценарий покрыт тестом.
+- Почему выбраны именно эти ветки (`happy path`, `error path`, `edge case`).
+- Результат `pnpm run ci:check` и тест-команды.
+
+---
+
+Owner по обновлению документа: `Sem` (или назначенный test-guide owner спринта).

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "ci:check": "pnpm lint && pnpm typecheck && pnpm build",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "echo \"Tests are not configured yet\" && exit 0"
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@eslint/eslintrc": "^3",
@@ -70,6 +71,7 @@
     "@typescript-eslint/parser": "^6.7.5",
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "msw": "^2.12.11",
     "prettier": "3.5.3",
     "sass": "^1.87.0",
     "stylelint": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.2(eslint@8.57.1)
+      msw:
+        specifier: ^2.12.11
+        version: 2.12.11(@types/node@20.19.31)(typescript@5.9.3)
       prettier:
         specifier: 3.5.3
         version: 3.5.3
@@ -158,7 +161,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.31)(sass@1.97.3)
+        version: 4.0.18(@types/node@20.19.31)(msw@2.12.11(@types/node@20.19.31)(typescript@5.9.3))(sass@1.97.3)
 
 packages:
 
@@ -601,6 +604,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@it-incubator/eslint-config@1.0.4':
     resolution: {integrity: sha512-1bRX1yvlPppZ8SJ0kJfR5z/2K60xPE11W9Ma1Vlk40JZRdCN6B+4lCqO+66Hn/oicfzlZAW62MbzzbNqSnMOfQ==}
     peerDependencies:
@@ -637,6 +675,10 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@mswjs/interceptors@0.41.3':
+    resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
+    engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -713,6 +755,15 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -1633,6 +1684,9 @@ packages:
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -2018,8 +2072,16 @@ packages:
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2041,6 +2103,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cosmiconfig@9.0.0:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
@@ -2214,6 +2280,10 @@ packages:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2498,6 +2568,10 @@ packages:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
@@ -2571,6 +2645,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  graphql@16.13.1:
+    resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
@@ -2609,6 +2687,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -2744,6 +2825,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -2946,6 +3030,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.12.11:
+    resolution: {integrity: sha512-dVg20zi2I2EvnwH/+WupzsOC2mCa7qsIhyMAWtfRikn6RKtwL9+7SaF1IQ5LyZry4tlUtf6KyTVhnlQiZXozTQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3039,6 +3137,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -3073,6 +3174,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3314,6 +3418,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -3336,6 +3444,9 @@ packages:
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
+
+  rettime@0.10.1:
+    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3459,12 +3570,19 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3612,6 +3730,10 @@ packages:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -3630,6 +3752,13 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.26:
+    resolution: {integrity: sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==}
+
+  tldts@7.0.26:
+    resolution: {integrity: sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3641,6 +3770,10 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
 
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
@@ -3661,6 +3794,10 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  type-fest@5.4.4:
+    resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -3700,6 +3837,9 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -3860,6 +4000,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3879,9 +4027,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4235,6 +4399,34 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/confirm@5.1.21(@types/node@20.19.31)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@20.19.31)
+      '@inquirer/type': 3.0.10(@types/node@20.19.31)
+    optionalDependencies:
+      '@types/node': 20.19.31
+
+  '@inquirer/core@10.3.2(@types/node@20.19.31)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@20.19.31)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.19.31
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/type@3.0.10(@types/node@20.19.31)':
+    optionalDependencies:
+      '@types/node': 20.19.31
+
   '@it-incubator/eslint-config@1.0.4(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint-config-prettier@9.1.2(eslint@8.57.1))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint-plugin-import@2.32.0)(eslint-plugin-perfectionist@2.11.0(eslint@8.57.1)(typescript@5.9.3))(eslint-plugin-prettier@5.5.5(eslint-config-prettier@9.1.2(eslint@8.57.1))(eslint@8.57.1)(prettier@3.5.3))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1)':
     dependencies:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
@@ -4268,6 +4460,15 @@ snapshots:
       keyv: 5.6.0
 
   '@keyv/serialize@1.1.1': {}
+
+  '@mswjs/interceptors@0.41.3':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4326,6 +4527,15 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -5179,6 +5389,8 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
+  '@types/statuses@2.0.6': {}
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
@@ -5375,12 +5587,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.31)(sass@1.97.3))':
+  '@vitest/mocker@4.0.18(msw@2.12.11(@types/node@20.19.31)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.31)(sass@1.97.3))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.12.11(@types/node@20.19.31)(typescript@5.9.3)
       vite: 7.3.1(@types/node@20.19.31)(sass@1.97.3)
 
   '@vitest/pretty-format@4.0.18':
@@ -5601,7 +5814,15 @@ snapshots:
 
   classnames@2.5.1: {}
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
@@ -5616,6 +5837,8 @@ snapshots:
   commander@7.2.0: {}
 
   concat-map@0.0.1: {}
+
+  cookie@1.1.1: {}
 
   cosmiconfig@9.0.0(typescript@5.9.3):
     dependencies:
@@ -5869,6 +6092,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -6222,6 +6447,8 @@ snapshots:
 
   generator-function@2.0.1: {}
 
+  get-caller-file@2.0.5: {}
+
   get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
@@ -6316,6 +6543,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  graphql@16.13.1: {}
+
   gzip-size@6.0.0:
     dependencies:
       duplexer: 0.1.2
@@ -6347,6 +6576,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  headers-polyfill@4.0.3: {}
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -6475,6 +6706,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -6656,6 +6889,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.12.11(@types/node@20.19.31)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@20.19.31)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.1
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.4.4
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@2.0.0: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -6754,6 +7014,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  outvariant@1.4.3: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -6786,6 +7048,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -7008,6 +7272,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   reselect@5.1.1: {}
@@ -7027,6 +7293,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rettime@0.10.1: {}
 
   reusify@1.1.0: {}
 
@@ -7221,12 +7489,16 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -7429,6 +7701,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tagged-tag@1.0.0: {}
+
   text-table@0.2.0: {}
 
   tinybench@2.9.0: {}
@@ -7442,6 +7716,12 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@7.0.26: {}
+
+  tldts@7.0.26:
+    dependencies:
+      tldts-core: 7.0.26
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -7453,6 +7733,10 @@ snapshots:
       ieee754: 1.2.1
 
   totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.26
 
   ts-api-utils@1.4.3(typescript@5.9.3):
     dependencies:
@@ -7472,6 +7756,10 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.20.2: {}
+
+  type-fest@5.4.4:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -7545,6 +7833,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  until-async@3.0.2: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -7589,10 +7879,10 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.97.3
 
-  vitest@4.0.18(@types/node@20.19.31)(sass@1.97.3):
+  vitest@4.0.18(@types/node@20.19.31)(msw@2.12.11(@types/node@20.19.31)(typescript@5.9.3))(sass@1.97.3):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.31)(sass@1.97.3))
+      '@vitest/mocker': 4.0.18(msw@2.12.11(@types/node@20.19.31)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.31)(sass@1.97.3))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -7703,6 +7993,18 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   write-file-atomic@7.0.1:
@@ -7711,6 +8013,22 @@ snapshots:
 
   ws@7.5.10: {}
 
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zod@3.25.76: {}

--- a/src/features/subscriptions/api/subscriptionsApi.msw.test.ts
+++ b/src/features/subscriptions/api/subscriptionsApi.msw.test.ts
@@ -1,0 +1,89 @@
+import { API_ROUTES } from '@/shared/api'
+import {
+  PaymentType,
+  SubscriptionType,
+  GetCurrentSubscriptionResponseDto,
+  CreateSubscriptionResponseDto,
+  GetPricingResponseDto,
+} from '@/shared/types'
+import { server } from '@/test/msw'
+import { configureStore } from '@reduxjs/toolkit'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { subscriptionsApi } from './subscriptionsApi'
+
+const createTestStore = () =>
+  configureStore({
+    reducer: {
+      [subscriptionsApi.reducerPath]: subscriptionsApi.reducer,
+    },
+    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(subscriptionsApi.middleware),
+  })
+
+describe('subscriptionsApi + MSW', () => {
+  it('returns pricing data from MSW handler', async () => {
+    const store = createTestStore()
+    const pricingResponse: GetPricingResponseDto = {
+      data: [
+        { amount: 10, typeDescription: SubscriptionType.DAY },
+        { amount: 100, typeDescription: SubscriptionType.MONTHLY },
+      ],
+    }
+
+    server.use(
+      http.get(`*${API_ROUTES.SUBSCRIPTIONS.COST_OF_PAYMENT}`, () =>
+        HttpResponse.json<GetPricingResponseDto>(pricingResponse)
+      )
+    )
+
+    const result = await store.dispatch(subscriptionsApi.endpoints.getPricing.initiate()).unwrap()
+
+    expect(result).toEqual(pricingResponse)
+  })
+
+  it('returns current subscription data from MSW handler', async () => {
+    const store = createTestStore()
+    const currentSubscriptionResponse: GetCurrentSubscriptionResponseDto = {
+      data: [],
+      hasAutoRenewal: false,
+    }
+
+    server.use(
+      http.get(`*${API_ROUTES.SUBSCRIPTIONS.CURRENT_PAYMENT}`, () =>
+        HttpResponse.json<GetCurrentSubscriptionResponseDto>(currentSubscriptionResponse)
+      )
+    )
+
+    const result = await store
+      .dispatch(subscriptionsApi.endpoints.getCurrentSubscription.initiate())
+      .unwrap()
+
+    expect(result).toEqual(currentSubscriptionResponse)
+  })
+
+  it('handles createSubscription 409 error from MSW handler', async () => {
+    const store = createTestStore()
+
+    server.use(
+      http.post(`*${API_ROUTES.SUBSCRIPTIONS.CREATE}`, () =>
+        HttpResponse.json({ message: 'Subscription conflict' }, { status: 409 })
+      )
+    )
+
+    const promise = store
+      .dispatch(
+        subscriptionsApi.endpoints.createSubscription.initiate({
+          typeSubscription: SubscriptionType.MONTHLY,
+          paymentType: PaymentType.STRIPE,
+          amount: 100,
+          baseUrl: 'http://localhost:3000',
+        })
+      )
+      .unwrap()
+
+    await expect(promise).rejects.toMatchObject({
+      status: 409,
+    })
+  })
+})

--- a/src/features/subscriptions/api/subscriptionsApi.test.ts
+++ b/src/features/subscriptions/api/subscriptionsApi.test.ts
@@ -24,6 +24,16 @@ const asNoContentResponse = () =>
     status: 204,
   })
 
+const asRequest = (call: unknown[]) => {
+  const [input, init] = call as [Request | URL | string, Record<string, unknown> | undefined]
+
+  if (input instanceof Request) {
+    return input
+  }
+
+  return new Request(String(input), init as ConstructorParameters<typeof Request>[1])
+}
+
 describe('subscriptionsApi', () => {
   it('calls getPricing endpoint with correct route', async () => {
     const fetchMock = vi.fn().mockResolvedValue(asJsonResponse({ data: [] }))
@@ -35,9 +45,9 @@ describe('subscriptionsApi', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    const [url] = fetchMock.mock.calls[0]
+    const request = asRequest(fetchMock.mock.calls[0])
 
-    expect(String(url)).toContain(API_ROUTES.SUBSCRIPTIONS.COST_OF_PAYMENT)
+    expect(request.url).toContain(API_ROUTES.SUBSCRIPTIONS.COST_OF_PAYMENT)
   })
 
   it('calls createSubscription endpoint with POST body', async () => {
@@ -58,11 +68,11 @@ describe('subscriptionsApi', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    const [url, init] = fetchMock.mock.calls[0]
+    const request = asRequest(fetchMock.mock.calls[0])
 
-    expect(String(url)).toContain(API_ROUTES.SUBSCRIPTIONS.CREATE)
-    expect(init?.method).toBe('POST')
-    expect(init?.body).toBe(JSON.stringify(payload))
+    expect(request.url).toContain(API_ROUTES.SUBSCRIPTIONS.CREATE)
+    expect(request.method).toBe('POST')
+    await expect(request.text()).resolves.toBe(JSON.stringify(payload))
   })
 
   it('calls getCurrentSubscription endpoint with correct route', async () => {
@@ -77,9 +87,9 @@ describe('subscriptionsApi', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    const [url] = fetchMock.mock.calls[0]
+    const request = asRequest(fetchMock.mock.calls[0])
 
-    expect(String(url)).toContain(API_ROUTES.SUBSCRIPTIONS.CURRENT_PAYMENT)
+    expect(request.url).toContain(API_ROUTES.SUBSCRIPTIONS.CURRENT_PAYMENT)
   })
 
   it('calls getPayments endpoint with default query params', async () => {
@@ -96,8 +106,8 @@ describe('subscriptionsApi', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    const [url] = fetchMock.mock.calls[0]
-    const requestUrl = new URL(String(url))
+    const request = asRequest(fetchMock.mock.calls[0])
+    const requestUrl = new URL(request.url)
 
     expect(requestUrl.pathname).toContain(API_ROUTES.SUBSCRIPTIONS.MY_PAYMENTS)
     expect(requestUrl.searchParams.get('pageNumber')).toBe('1')
@@ -116,10 +126,10 @@ describe('subscriptionsApi', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    const [url, init] = fetchMock.mock.calls[0]
+    const request = asRequest(fetchMock.mock.calls[0])
 
-    expect(String(url)).toContain(API_ROUTES.SUBSCRIPTIONS.CANCEL_AUTO_RENEWAL)
-    expect(init?.method).toBe('POST')
+    expect(request.url).toContain(API_ROUTES.SUBSCRIPTIONS.CANCEL_AUTO_RENEWAL)
+    expect(request.method).toBe('POST')
   })
 
   it('calls renewAutoRenewal endpoint with POST', async () => {
@@ -132,9 +142,9 @@ describe('subscriptionsApi', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    const [url, init] = fetchMock.mock.calls[0]
+    const request = asRequest(fetchMock.mock.calls[0])
 
-    expect(String(url)).toContain(API_ROUTES.SUBSCRIPTIONS.RENEW_AUTO_RENEWAL)
-    expect(init?.method).toBe('POST')
+    expect(request.url).toContain(API_ROUTES.SUBSCRIPTIONS.RENEW_AUTO_RENEWAL)
+    expect(request.method).toBe('POST')
   })
 })

--- a/src/shared/ui/SVGComponents/index.ts
+++ b/src/shared/ui/SVGComponents/index.ts
@@ -1,35 +1,35 @@
-export {
-  PaperPlane,
-  HeartOutline,
-  GitHub,
-  Google,
-  BellOutline,
-  RussiaFlag,
-  UkFlag,
-  ArrowBack,
-  ArrowForwardSimple,
-  ArrowBackSimple,
-  PlusCircle,
-  Expand,
-  TrendingUp,
-  Bookmark,
-  BookmarkOutline,
-  Home,
-  HomeOutline,
-  LogOut,
-  MessageCircle,
-  MessageCircleOutline,
-  Person,
-  PersonOutline,
-  PlusSquare,
-  PlusSquareOutline,
-  Search,
-  TrashOutline,
-  EditOutline,
-  ImageOutline,
-  MoreHorizontal,
-  Close,
-  PersonAddOutline,
-  CopyOutline,
-  Pin,
-} from '@ictroot/ui-kit/icons'
+import * as Icons from '@ictroot/ui-kit/icons'
+
+export const PaperPlane = Icons.PaperPlane
+export const HeartOutline = Icons.HeartOutline
+export const GitHub = Icons.GitHub
+export const Google = Icons.Google
+export const BellOutline = Icons.BellOutline
+export const RussiaFlag = Icons.RussiaFlag
+export const UkFlag = Icons.UkFlag
+export const ArrowBack = Icons.ArrowBack
+export const ArrowForwardSimple = Icons.ArrowForwardSimple
+export const ArrowBackSimple = Icons.ArrowBackSimple
+export const PlusCircle = Icons.PlusCircle
+export const Expand = Icons.Expand
+export const TrendingUp = Icons.TrendingUp
+export const Bookmark = Icons.Bookmark
+export const BookmarkOutline = Icons.BookmarkOutline
+export const Home = Icons.Home
+export const HomeOutline = Icons.HomeOutline
+export const LogOut = Icons.LogOut
+export const MessageCircle = Icons.MessageCircle
+export const MessageCircleOutline = Icons.MessageCircleOutline
+export const Person = Icons.Person
+export const PersonOutline = Icons.PersonOutline
+export const PlusSquare = Icons.PlusSquare
+export const PlusSquareOutline = Icons.PlusSquareOutline
+export const Search = Icons.Search
+export const TrashOutline = Icons.TrashOutline
+export const EditOutline = Icons.EditOutline
+export const ImageOutline = Icons.ImageOutline
+export const MoreHorizontal = Icons.MoreHorizontal
+export const Close = Icons.Close
+export const PersonAddOutline = Icons.PersonAddOutline
+export const CopyOutline = Icons.CopyOutline
+export const Pin = Icons.Pin

--- a/src/test/msw/handlers/subscriptions.handlers.ts
+++ b/src/test/msw/handlers/subscriptions.handlers.ts
@@ -1,0 +1,37 @@
+import { API_ROUTES } from '@/shared/api'
+import {
+  GetCurrentSubscriptionResponseDto,
+  GetPricingResponseDto,
+  SubscriptionType,
+} from '@/shared/types'
+import { http, HttpResponse } from 'msw'
+
+const pricingResponse: GetPricingResponseDto = {
+  data: [
+    { amount: 10, typeDescription: SubscriptionType.DAY },
+    { amount: 50, typeDescription: SubscriptionType.WEEKLY },
+    { amount: 100, typeDescription: SubscriptionType.MONTHLY },
+  ],
+}
+
+const currentSubscriptionResponse: GetCurrentSubscriptionResponseDto = {
+  data: [
+    {
+      userId: 1,
+      subscriptionId: 'sub_default_1',
+      dateOfPayment: '2026-03-10T00:00:00.000Z',
+      endDateOfSubscription: '2026-04-10T00:00:00.000Z',
+      autoRenewal: true,
+    },
+  ],
+  hasAutoRenewal: true,
+}
+
+export const subscriptionsHandlers = [
+  http.get(`*${API_ROUTES.SUBSCRIPTIONS.COST_OF_PAYMENT}`, () =>
+    HttpResponse.json<GetPricingResponseDto>(pricingResponse)
+  ),
+  http.get(`*${API_ROUTES.SUBSCRIPTIONS.CURRENT_PAYMENT}`, () =>
+    HttpResponse.json<GetCurrentSubscriptionResponseDto>(currentSubscriptionResponse)
+  ),
+]

--- a/src/test/msw/index.ts
+++ b/src/test/msw/index.ts
@@ -1,0 +1,1 @@
+export { server } from './server'

--- a/src/test/msw/server.ts
+++ b/src/test/msw/server.ts
@@ -1,0 +1,5 @@
+import { setupServer } from 'msw/node'
+
+import { subscriptionsHandlers } from './handlers/subscriptions.handlers'
+
+export const server = setupServer(...subscriptionsHandlers)

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,11 +1,15 @@
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 import { defineConfig } from 'vitest/config'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    setupFiles: ['./vitest.setup.ts'],
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,6 @@
+import { server } from '@/test/msw'
+import { afterAll, afterEach, beforeAll } from 'vitest'
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())


### PR DESCRIPTION
## Summary

- Jira: N/A
- What changed:
- Исправлен экспорт иконок в `src/shared/ui/SVGComponents/index.ts`:
  - заменён прямой re-export из `@ictroot/ui-kit/icons` на явный `import * as Icons` + локальные named exports.
- Цель: устранить падение prerender (`Element type is invalid`) на страницах legal и других местах, где иконки импортируются через `@/shared/ui`.

## Scope

### In scope

- Только стабилизация цепочки экспортов иконок в `shared/ui`.
- Проверка сборки после изменения (`pnpm build`).

### Out of scope

- Любые изменения бизнес-логики, UI-поведения и API.
- MSW/tests инфраструктура.
- Рефакторинг других модулей.

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

## Contract change

- N/A

## Mandatory checklist

- [ ] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- `pnpm build` -> passed.
- `/legal/terms-of-service` и `/legal/privacy-policy` успешно prerenderятся в build output.

### Manual

- Scenario 1: открыть legal pages и убедиться, что страница рендерится без runtime error.
- Scenario 2: проверить компоненты с иконками из `@/shared/ui` (header/sidebar/post modal).

## Risks and Rollback

- Risks:
- Низкий риск: изменён только способ экспорта, не сами иконки.
- Потенциальный риск — если в UI-kit изменятся имена иконок, потребуется синхронизация списка exports.

- Rollback plan:
- Revert commit с фиксом `SVGComponents/index.ts`.
