### PR TITLE
fix(api): guard production from relative proxy base

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,8 +2,14 @@ import type { NextConfig } from 'next'
 
 import withBundleAnalyzer from '@next/bundle-analyzer'
 
-const apiBase = process.env.NEXT_PUBLIC_API_URL || '/api/proxy'
-const apiProxyTarget = process.env.API_PROXY_TARGET || 'https://ictroot.uk/api'
+const DEFAULT_API_TARGET = 'https://ictroot.uk/api'
+const isProduction = process.env.NODE_ENV === 'production'
+const configuredApiBase = process.env.NEXT_PUBLIC_API_URL
+const apiProxyTarget = process.env.API_PROXY_TARGET || DEFAULT_API_TARGET
+const apiBase =
+  isProduction && configuredApiBase?.startsWith('/')
+    ? apiProxyTarget
+    : configuredApiBase || (isProduction ? apiProxyTarget : '/api/proxy')
 const normalizedApiBase = apiBase.replace(/\/+$/, '')
 const normalizedApiProxyTarget = apiProxyTarget.replace(/\/+$/, '')
 

--- a/src/shared/api/get-api-base-url.ts
+++ b/src/shared/api/get-api-base-url.ts
@@ -1,24 +1,29 @@
 const DEFAULT_DEV_API_BASE = '/api/proxy'
+const DEFAULT_API_TARGET = 'https://ictroot.uk/api'
 const DEFAULT_INTERNAL_ORIGIN = 'http://localhost:3000'
+const isProduction = process.env.NODE_ENV === 'production'
 
 const isAbsoluteUrl = (value: string) => /^https?:\/\//.test(value)
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
 const ensureLeadingSlash = (value: string) => (value.startsWith('/') ? value : `/${value}`)
 
 export const getApiBaseUrl = () => {
-  const configuredBase = process.env.NEXT_PUBLIC_API_URL || DEFAULT_DEV_API_BASE
+  const configuredBase =
+    process.env.NEXT_PUBLIC_API_URL || (isProduction ? DEFAULT_API_TARGET : DEFAULT_DEV_API_BASE)
   const normalizedBase = trimTrailingSlash(configuredBase)
+  const effectiveBase =
+    isProduction && normalizedBase.startsWith('/') ? DEFAULT_API_TARGET : normalizedBase
 
-  if (isAbsoluteUrl(normalizedBase)) {
-    return normalizedBase
+  if (isAbsoluteUrl(effectiveBase)) {
+    return effectiveBase
   }
 
   if (typeof window !== 'undefined') {
-    return ensureLeadingSlash(normalizedBase)
+    return ensureLeadingSlash(effectiveBase)
   }
 
-  if (normalizedBase.startsWith('/')) {
-    const apiProxyTarget = trimTrailingSlash(process.env.API_PROXY_TARGET || '')
+  if (effectiveBase.startsWith('/')) {
+    const apiProxyTarget = trimTrailingSlash(process.env.API_PROXY_TARGET || DEFAULT_API_TARGET)
 
     if (apiProxyTarget) {
       return apiProxyTarget
@@ -29,7 +34,7 @@ export const getApiBaseUrl = () => {
     process.env.INTERNAL_APP_ORIGIN || process.env.NEXT_PUBLIC_APP_ORIGIN || DEFAULT_INTERNAL_ORIGIN
   )
 
-  return `${internalOrigin}${ensureLeadingSlash(normalizedBase)}`
+  return `${internalOrigin}${ensureLeadingSlash(effectiveBase)}`
 }
 
 export const buildApiUrl = (path: string) => `${getApiBaseUrl()}${path}`


### PR DESCRIPTION
Summary
Production hotfix: guard API base resolution in production to prevent relative proxy base (`/api/proxy`) and force absolute API target.
Jira:
TBD
What changed:
- `next.config.ts`: added production guard for `NEXT_PUBLIC_API_URL`; in production relative base is replaced with absolute `API_PROXY_TARGET` (fallback `https://ictroot.uk/api`).
- `src/shared/api/get-api-base-url.ts`: aligned runtime resolution logic with the same production guard and absolute fallback target.
- Ensured consistent behavior between Next rewrites config and API URL builder.

Scope
In scope
- Production API base URL resolution.
- Proxy/rewrite behavior when `NEXT_PUBLIC_API_URL` is relative.
Out of scope
- API contract changes.
- UI/business logic changes.
- Backend changes.

Architecture impact
- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

If architectural change is checked:
- add label policy-change
- fill Contract change section
- update .ai/policy.md version metadata

Contract change
What changed:
N/A
Why:
N/A
Impact/Migration:
N/A
Policy version updated:
N/A

Mandatory checklist
- [ ] pnpm run ci:check is green
- [x] No new any in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

Verification evidence
Automated
Commands and result:
- `pnpm run ci:check` — pending / fill after CI run.

Manual
Scenario 1:
- Production mode + `NEXT_PUBLIC_API_URL=/api/proxy` -> app uses absolute API target (`API_PROXY_TARGET` or `https://ictroot.uk/api`), no relative proxy base in production.
Scenario 2:
- Development mode without explicit `NEXT_PUBLIC_API_URL` -> keeps `/api/proxy` flow for local proxy usage.

Risks and Rollback
Risks:
- If `API_PROXY_TARGET` is misconfigured, production traffic may go to fallback target unexpectedly.
- Environments relying on relative production base may observe routing behavior change.
Rollback plan:
- Revert commit `3743bbbd5c90e7471dd31f9ffd1c491903061ec4`.
- Redeploy previous stable build.
- As immediate mitigation, set explicit correct `API_PROXY_TARGET`/`NEXT_PUBLIC_API_URL` (absolute URL).
