### PR TITLE
fix(api): enforce strict prod API URL and avoid baked offline SSR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Public frontend API endpoint
 # In local dev, use same-origin proxy to avoid CORS/mobile tunnel issues.
 # Example: /api/proxy
+# In production this value is required and must be absolute (e.g. https://api.example.com/api).
 NEXT_PUBLIC_API_URL=
 
 # Proxy target used by next.config.ts rewrites when NEXT_PUBLIC_API_URL starts with "/"

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,16 +2,25 @@ import type { NextConfig } from 'next'
 
 import withBundleAnalyzer from '@next/bundle-analyzer'
 
-const DEFAULT_API_TARGET = 'https://ictroot.uk/api'
 const isProduction = process.env.NODE_ENV === 'production'
-const configuredApiBase = process.env.NEXT_PUBLIC_API_URL
-const apiProxyTarget = process.env.API_PROXY_TARGET || DEFAULT_API_TARGET
-const apiBase =
-  isProduction && configuredApiBase?.startsWith('/')
-    ? apiProxyTarget
-    : configuredApiBase || (isProduction ? apiProxyTarget : '/api/proxy')
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
+
+const configuredApiBase = process.env.NEXT_PUBLIC_API_URL?.trim() || ''
+
+if (isProduction) {
+  if (!configuredApiBase) {
+    throw new Error('NEXT_PUBLIC_API_URL must be defined in production')
+  }
+
+  if (configuredApiBase.startsWith('/')) {
+    throw new Error('NEXT_PUBLIC_API_URL must be an absolute URL in production')
+  }
+}
+
+const apiBase = configuredApiBase || '/api/proxy'
+const apiProxyTarget = process.env.API_PROXY_TARGET?.trim() || ''
 const normalizedApiBase = apiBase.replace(/\/+$/, '')
-const normalizedApiProxyTarget = apiProxyTarget.replace(/\/+$/, '')
+const normalizedApiProxyTarget = trimTrailingSlash(apiProxyTarget)
 
 const nextConfig: NextConfig = {
   images: {
@@ -26,6 +35,10 @@ const nextConfig: NextConfig = {
   },
   async rewrites() {
     if (!normalizedApiBase.startsWith('/')) {
+      return []
+    }
+
+    if (!normalizedApiProxyTarget) {
       return []
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import { GetPublicPostsResponse } from '@/entities/users/api/api.types'
 import { Public } from '@/entities/users/ui'
-import { ApiErrorBoundary } from '@/lib/ApiErrorBoundary'
-import { apiFetch, ApiError } from '@/lib/api'
+import { apiFetch } from '@/lib/api'
 import { API_ROUTES } from '@/shared/api'
 import { buildApiUrl } from '@/shared/api/get-api-base-url'
 
@@ -23,11 +22,12 @@ const fetchPublicPostsForSSR = async () => {
 
 export default async function HomePage() {
   const { data, error } = await fetchPublicPostsForSSR()
-  const apiError: ApiError | null = error || null
 
-  return (
-    <ApiErrorBoundary error={apiError}>
-      {data ? <Public postsData={data} /> : <div>Данные отсутствуют</div>}
-    </ApiErrorBoundary>
-  )
+  // Avoid baking transient network errors into static HTML during build/ISR.
+  // When SSR fetch fails, client-side query in <Public /> will retry after hydration.
+  if (error || !data) {
+    return <Public />
+  }
+
+  return <Public postsData={data} />
 }

--- a/src/entities/users/ui/public/Public.tsx
+++ b/src/entities/users/ui/public/Public.tsx
@@ -15,7 +15,7 @@ import { PublicPost } from './PublicPost/PublicPost'
 import { UsersCounter } from './UsersCounter/UsersCounter'
 
 type Props = {
-  postsData: GetPublicPostsResponse
+  postsData?: GetPublicPostsResponse
 }
 
 const LCP_PRIORITY_POSTS_COUNT = 1

--- a/src/shared/api/get-api-base-url.ts
+++ b/src/shared/api/get-api-base-url.ts
@@ -1,5 +1,4 @@
 const DEFAULT_DEV_API_BASE = '/api/proxy'
-const DEFAULT_API_TARGET = 'https://ictroot.uk/api'
 const DEFAULT_INTERNAL_ORIGIN = 'http://localhost:3000'
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -7,12 +6,27 @@ const isAbsoluteUrl = (value: string) => /^https?:\/\//.test(value)
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
 const ensureLeadingSlash = (value: string) => (value.startsWith('/') ? value : `/${value}`)
 
+const getRequiredProductionApiBase = () => {
+  const configuredBase = trimTrailingSlash(process.env.NEXT_PUBLIC_API_URL?.trim() || '')
+
+  if (!configuredBase) {
+    throw new Error('NEXT_PUBLIC_API_URL must be defined in production')
+  }
+
+  if (!isAbsoluteUrl(configuredBase)) {
+    throw new Error('NEXT_PUBLIC_API_URL must be an absolute URL in production')
+  }
+
+  return configuredBase
+}
+
 export const getApiBaseUrl = () => {
-  const configuredBase =
-    process.env.NEXT_PUBLIC_API_URL || (isProduction ? DEFAULT_API_TARGET : DEFAULT_DEV_API_BASE)
-  const normalizedBase = trimTrailingSlash(configuredBase)
-  const effectiveBase =
-    isProduction && normalizedBase.startsWith('/') ? DEFAULT_API_TARGET : normalizedBase
+  if (isProduction) {
+    return getRequiredProductionApiBase()
+  }
+
+  const configuredBase = process.env.NEXT_PUBLIC_API_URL?.trim() || DEFAULT_DEV_API_BASE
+  const effectiveBase = trimTrailingSlash(configuredBase)
 
   if (isAbsoluteUrl(effectiveBase)) {
     return effectiveBase
@@ -23,7 +37,7 @@ export const getApiBaseUrl = () => {
   }
 
   if (effectiveBase.startsWith('/')) {
-    const apiProxyTarget = trimTrailingSlash(process.env.API_PROXY_TARGET || DEFAULT_API_TARGET)
+    const apiProxyTarget = trimTrailingSlash(process.env.API_PROXY_TARGET?.trim() || '')
 
     if (apiProxyTarget) {
       return apiProxyTarget


### PR DESCRIPTION
Summary
Jira:
What changed:
- Убрали “запекание” offline-UI на `/`: при SSR-ошибке главная страница больше не рендерит `ApiErrorBoundary`, а уходит в клиентский fetch (`Public` без `postsData`).
- `Public` теперь принимает `postsData` как optional для fallback-сценария.
- Ввели strict guard для production: `NEXT_PUBLIC_API_URL` обязателен и должен быть absolute URL.
- Убрали hardcoded fallback `https://ictroot.uk/api`; proxy target теперь только из env (`API_PROXY_TARGET`).
- Обновили комментарии в `.env.example`/`.env.production`.

Scope
In scope
- Фикс offline-экрана, который раньше мог попасть в build-артефакт.
- Валидация production-конфига API на этапе build/start.
- Очистка hardcoded API target из runtime/config logic.
Out of scope
- Backend/API-контракты.
- Изменения бизнес-логики подписок/автореневала.
- Изменения UI/дизайна страниц.

Architecture impact
- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

Contract change
What changed:
- Контракт API не менялся.
Why:
- N/A
Impact/Migration:
- Для production обязательно задавать `NEXT_PUBLIC_API_URL` как absolute URL.
- `NEXT_PUBLIC_API_URL=/api/proxy` в production теперь валидно падает на build.
Policy version updated:
- N/A

Mandatory checklist
- [x] pnpm run ci:check is green
- [x] No new any in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

Verification evidence
Automated
Commands and result:
- `NEXT_PUBLIC_API_URL=/api/proxy pnpm build` -> expected fail (`NEXT_PUBLIC_API_URL must be an absolute URL in production`)
- `NEXT_PUBLIC_API_URL=https://ictroot.uk/api pnpm build` -> success
- `NEXT_PUBLIC_API_URL=https://nonexistent.invalid/api pnpm build` -> success
- `grep -nE "Server Unavailable|No Internet|Please check your internet connection" .next/server/app/index.* || echo "OK: offline UI не запечён"` -> `OK: offline UI не запечён`
- `PORT=3001 NEXT_PUBLIC_API_URL=https://ictroot.uk/api pnpm start` -> app started successfully
- `NEXT_PUBLIC_API_URL=https://ictroot.uk/api pnpm run ci:check` -> passed (warnings only)

Manual
Scenario 1:
- Build/start с `NEXT_PUBLIC_API_URL=https://ictroot.uk/api`, открыть `/`, hard refresh.
- Ожидание: страница не стартует с `Server Unavailable`, данные грузятся штатно.
Scenario 2:
- Build с невалидным API host (`https://nonexistent.invalid/api`) и проверка `.next/server/app/index.*`.
- Ожидание: offline-UI не “запечён” в HTML/RSC.

Risks and Rollback
Risks:
- Production build будет падать, если `NEXT_PUBLIC_API_URL` не задан или задан как relative URL.
- При недоступном API на момент SSR пользователь увидит клиентский fallback до восстановления сети/API.
Rollback plan:
- Revert commit `0c7d374`.
- Пересобрать и задеплоить предыдущую стабильную ревизию.
