### PR TITLE
Hotfix/prod api url guard offline ssr

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Public frontend API endpoint
 # In local dev, use same-origin proxy to avoid CORS/mobile tunnel issues.
 # Example: /api/proxy
+# In production this value is required and must be absolute (e.g. https://api.example.com/api).
 NEXT_PUBLIC_API_URL=
 
 # Proxy target used by next.config.ts rewrites when NEXT_PUBLIC_API_URL starts with "/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN npm install
 #но package.json остался неизменным, то стейдж с установкой зависимостей повторно не выполняется, что экономит время.
 FROM node:20.11-alpine as builder
 WORKDIR /app
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 COPY . .
 COPY --from=dependencies /app/node_modules ./node_modules
 RUN npm run build:production
@@ -16,7 +18,9 @@ RUN npm run build:production
 #Стейдж запуска
 FROM node:20.11-alpine as runner
 WORKDIR /app
+ARG NEXT_PUBLIC_API_URL
 ENV NODE_ENV production
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 COPY --from=builder /app/ ./
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         REGISTRY = "registry.hub.docker.com"
         PROJECT = "ictroot"
         DEPLOYMENT_NAME = "ictroot-deployment"
+        NEXT_PUBLIC_API_URL = "https://ictroot.uk/api"
         IMAGE_NAME = "${env.BUILD_ID}_${env.ENV_TYPE}_${env.GIT_COMMIT}"
         DOCKER_BUILD_NAME = "${env.REGISTRY_HOSTNAME}/${env.PROJECT}:${env.IMAGE_NAME}"
     }
@@ -38,7 +39,10 @@ pipeline {
             steps {
                 echo "Build image started..."
                     script {
-                        app = docker.build("${env.DOCKER_BUILD_NAME}")
+                        app = docker.build(
+                            "${env.DOCKER_BUILD_NAME}",
+                            "--build-arg NEXT_PUBLIC_API_URL=${env.NEXT_PUBLIC_API_URL} ."
+                        )
                     }
                 echo "Build image finished..."
             }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,16 +2,25 @@ import type { NextConfig } from 'next'
 
 import withBundleAnalyzer from '@next/bundle-analyzer'
 
-const DEFAULT_API_TARGET = 'https://ictroot.uk/api'
 const isProduction = process.env.NODE_ENV === 'production'
-const configuredApiBase = process.env.NEXT_PUBLIC_API_URL
-const apiProxyTarget = process.env.API_PROXY_TARGET || DEFAULT_API_TARGET
-const apiBase =
-  isProduction && configuredApiBase?.startsWith('/')
-    ? apiProxyTarget
-    : configuredApiBase || (isProduction ? apiProxyTarget : '/api/proxy')
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
+
+const configuredApiBase = process.env.NEXT_PUBLIC_API_URL?.trim() || ''
+
+if (isProduction) {
+  if (!configuredApiBase) {
+    throw new Error('NEXT_PUBLIC_API_URL must be defined in production')
+  }
+
+  if (configuredApiBase.startsWith('/')) {
+    throw new Error('NEXT_PUBLIC_API_URL must be an absolute URL in production')
+  }
+}
+
+const apiBase = configuredApiBase || '/api/proxy'
+const apiProxyTarget = process.env.API_PROXY_TARGET?.trim() || ''
 const normalizedApiBase = apiBase.replace(/\/+$/, '')
-const normalizedApiProxyTarget = apiProxyTarget.replace(/\/+$/, '')
+const normalizedApiProxyTarget = trimTrailingSlash(apiProxyTarget)
 
 const nextConfig: NextConfig = {
   images: {
@@ -26,6 +35,10 @@ const nextConfig: NextConfig = {
   },
   async rewrites() {
     if (!normalizedApiBase.startsWith('/')) {
+      return []
+    }
+
+    if (!normalizedApiProxyTarget) {
       return []
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import { GetPublicPostsResponse } from '@/entities/users/api/api.types'
 import { Public } from '@/entities/users/ui'
-import { ApiErrorBoundary } from '@/lib/ApiErrorBoundary'
-import { apiFetch, ApiError } from '@/lib/api'
+import { apiFetch } from '@/lib/api'
 import { API_ROUTES } from '@/shared/api'
 import { buildApiUrl } from '@/shared/api/get-api-base-url'
 
@@ -23,11 +22,12 @@ const fetchPublicPostsForSSR = async () => {
 
 export default async function HomePage() {
   const { data, error } = await fetchPublicPostsForSSR()
-  const apiError: ApiError | null = error || null
 
-  return (
-    <ApiErrorBoundary error={apiError}>
-      {data ? <Public postsData={data} /> : <div>Данные отсутствуют</div>}
-    </ApiErrorBoundary>
-  )
+  // Avoid baking transient network errors into static HTML during build/ISR.
+  // When SSR fetch fails, client-side query in <Public /> will retry after hydration.
+  if (error || !data) {
+    return <Public />
+  }
+
+  return <Public postsData={data} />
 }

--- a/src/entities/users/ui/public/Public.tsx
+++ b/src/entities/users/ui/public/Public.tsx
@@ -15,7 +15,7 @@ import { PublicPost } from './PublicPost/PublicPost'
 import { UsersCounter } from './UsersCounter/UsersCounter'
 
 type Props = {
-  postsData: GetPublicPostsResponse
+  postsData?: GetPublicPostsResponse
 }
 
 const LCP_PRIORITY_POSTS_COUNT = 1

--- a/src/shared/api/get-api-base-url.ts
+++ b/src/shared/api/get-api-base-url.ts
@@ -1,5 +1,4 @@
 const DEFAULT_DEV_API_BASE = '/api/proxy'
-const DEFAULT_API_TARGET = 'https://ictroot.uk/api'
 const DEFAULT_INTERNAL_ORIGIN = 'http://localhost:3000'
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -7,12 +6,27 @@ const isAbsoluteUrl = (value: string) => /^https?:\/\//.test(value)
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
 const ensureLeadingSlash = (value: string) => (value.startsWith('/') ? value : `/${value}`)
 
+const getRequiredProductionApiBase = () => {
+  const configuredBase = trimTrailingSlash(process.env.NEXT_PUBLIC_API_URL?.trim() || '')
+
+  if (!configuredBase) {
+    throw new Error('NEXT_PUBLIC_API_URL must be defined in production')
+  }
+
+  if (!isAbsoluteUrl(configuredBase)) {
+    throw new Error('NEXT_PUBLIC_API_URL must be an absolute URL in production')
+  }
+
+  return configuredBase
+}
+
 export const getApiBaseUrl = () => {
-  const configuredBase =
-    process.env.NEXT_PUBLIC_API_URL || (isProduction ? DEFAULT_API_TARGET : DEFAULT_DEV_API_BASE)
-  const normalizedBase = trimTrailingSlash(configuredBase)
-  const effectiveBase =
-    isProduction && normalizedBase.startsWith('/') ? DEFAULT_API_TARGET : normalizedBase
+  if (isProduction) {
+    return getRequiredProductionApiBase()
+  }
+
+  const configuredBase = process.env.NEXT_PUBLIC_API_URL?.trim() || DEFAULT_DEV_API_BASE
+  const effectiveBase = trimTrailingSlash(configuredBase)
 
   if (isAbsoluteUrl(effectiveBase)) {
     return effectiveBase
@@ -23,7 +37,7 @@ export const getApiBaseUrl = () => {
   }
 
   if (effectiveBase.startsWith('/')) {
-    const apiProxyTarget = trimTrailingSlash(process.env.API_PROXY_TARGET || DEFAULT_API_TARGET)
+    const apiProxyTarget = trimTrailingSlash(process.env.API_PROXY_TARGET?.trim() || '')
 
     if (apiProxyTarget) {
       return apiProxyTarget


### PR DESCRIPTION
## Summary

- Jira:
- What changed:
- Исправлен SSR fallback на `/`: при ошибке server fetch больше не рендерится offline-экран в build-артефакт; рендерится `<Public />`, клиент догружает данные после hydration.
- В `Public` сделан fallback-сценарий: `postsData` optional.
- Добавлен strict guard для production: `NEXT_PUBLIC_API_URL` обязателен и должен быть absolute URL.
- Убраны hardcoded fallback-значения API target в runtime/config.
- Для CI добавлена явная передача `NEXT_PUBLIC_API_URL` в Docker build (Jenkins `--build-arg` + Dockerfile `ARG/ENV`).

## Scope

### In scope

- Фикс “baked offline UI” на главной странице `/`.
- Strict env-валидация API URL для production.
- Актуализация CI/docker build под новые env-требования.

### Out of scope

- Backend API и контрактные изменения.
- Бизнес-логика подписок/автореневала.
- Полная чистка существующих lint warnings.

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

If architectural change is checked:

- add label `policy-change`
- fill `Contract change` section
- update `.ai/policy.md` version metadata

## Contract change

- What changed: API contract не менялся.
- Why: изменения только во frontend SSR/env/config.
- Impact/Migration: в production обязательно задавать `NEXT_PUBLIC_API_URL` как absolute URL.
- Policy version updated: N/A

## Mandatory checklist

- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
- `NEXT_PUBLIC_API_URL=/api/proxy pnpm build` -> expected fail (`NEXT_PUBLIC_API_URL must be an absolute URL in production`)
- `NEXT_PUBLIC_API_URL=https://ictroot.uk/api pnpm build` -> success
- `NEXT_PUBLIC_API_URL=https://nonexistent.invalid/api pnpm build` -> success
- `grep -nE "Server Unavailable|No Internet|Please check your internet connection" .next/server/app/index.* || echo "OK: offline UI не запечён"` -> `OK: offline UI не запечён`
- `NEXT_PUBLIC_API_URL=https://ictroot.uk/api pnpm run ci:check` -> passed (warnings only)

### Manual

- Scenario 1:
- Запустить production (`pnpm start`), открыть `/`, сделать hard refresh.
- Ожидание: стартовый `Server Unavailable` не появляется из SSR-артефакта.
- Scenario 2:
- Запустить Jenkins PR pipeline с актуальными правками Docker/Jenkins.
- Ожидание: `npm run build:production` проходит без `NEXT_PUBLIC_API_URL must be defined in production`.

## Risks and Rollback

- Risks:
- При отсутствии `NEXT_PUBLIC_API_URL` в production/CI сборка падает fail-fast.
- При временной недоступности API на SSR возможен клиентский fallback до восстановления API.
- Rollback plan:
- Если CI с build-arg не стабилизируется, применить Plan B:
- откатить strict/env+infra часть (`next.config.ts`, `get-api-base-url.ts`, `Jenkinsfile`, `Dockerfile`) к предыдущей мягкой схеме;
- оставить только SSR-fallback fix для `/`.
