### PR TITLE
Hotfix/prod api url guard offline ssr

### DIFF
--- a/.ai/anti-patterns.md
+++ b/.ai/anti-patterns.md
@@ -9,3 +9,4 @@
 - Hardcoded user-facing строки в обход i18n.
 - Double source of truth для readiness/validation.
 - Silent deviation from policy: нарушение policy без TODO/issue и без фиксации в PR.
+- Для SSR/ISR (`revalidate`) возвращать error UI из server fetch-path при transient ошибках (`FETCH_ERROR`, `5xx`, timeout). Это приводит к "запеканию" ошибки в HTML/cache.

--- a/.ai/playbooks/pr-review.md
+++ b/.ai/playbooks/pr-review.md
@@ -13,6 +13,7 @@
 - Нет бизнес-логики в UI.
 - Нет нарушений dependency direction.
 - Нет новых запрещённых паттернов.
+- Для SSR/ISR (`revalidate`) проверено, что transient fetch-ошибки не "запекают" error UI в SSR output/cache.
 - Приложены результаты проверок.
 
 ## PR evidence

--- a/.ai/quality-gates.md
+++ b/.ai/quality-gates.md
@@ -27,6 +27,7 @@
 - post upload/publish,
 - edit profile,
 - i18n language switch.
+- Для SSR/ISR-страниц (`revalidate`) подтверждено, что transient fetch-ошибки не рендерят и не кэшируют error UI как успешный SSR-результат.
 
 ## Infrastructure constraints (educational project)
 

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Public frontend API endpoint
 # In local dev, use same-origin proxy to avoid CORS/mobile tunnel issues.
 # Example: /api/proxy
+# In production this value is required and must be absolute (e.g. https://api.example.com/api).
 NEXT_PUBLIC_API_URL=
 
 # Proxy target used by next.config.ts rewrites when NEXT_PUBLIC_API_URL starts with "/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN npm install
 #но package.json остался неизменным, то стейдж с установкой зависимостей повторно не выполняется, что экономит время.
 FROM node:20.11-alpine as builder
 WORKDIR /app
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 COPY . .
 COPY --from=dependencies /app/node_modules ./node_modules
 RUN npm run build:production
@@ -16,7 +18,9 @@ RUN npm run build:production
 #Стейдж запуска
 FROM node:20.11-alpine as runner
 WORKDIR /app
+ARG NEXT_PUBLIC_API_URL
 ENV NODE_ENV production
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 COPY --from=builder /app/ ./
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         REGISTRY = "registry.hub.docker.com"
         PROJECT = "ictroot"
         DEPLOYMENT_NAME = "ictroot-deployment"
+        NEXT_PUBLIC_API_URL = "https://ictroot.uk/api"
         IMAGE_NAME = "${env.BUILD_ID}_${env.ENV_TYPE}_${env.GIT_COMMIT}"
         DOCKER_BUILD_NAME = "${env.REGISTRY_HOSTNAME}/${env.PROJECT}:${env.IMAGE_NAME}"
     }
@@ -38,7 +39,10 @@ pipeline {
             steps {
                 echo "Build image started..."
                     script {
-                        app = docker.build("${env.DOCKER_BUILD_NAME}")
+                        app = docker.build(
+                            "${env.DOCKER_BUILD_NAME}",
+                            "--build-arg NEXT_PUBLIC_API_URL=${env.NEXT_PUBLIC_API_URL} ."
+                        )
                     }
                 echo "Build image finished..."
             }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,16 +2,25 @@ import type { NextConfig } from 'next'
 
 import withBundleAnalyzer from '@next/bundle-analyzer'
 
-const DEFAULT_API_TARGET = 'https://ictroot.uk/api'
 const isProduction = process.env.NODE_ENV === 'production'
-const configuredApiBase = process.env.NEXT_PUBLIC_API_URL
-const apiProxyTarget = process.env.API_PROXY_TARGET || DEFAULT_API_TARGET
-const apiBase =
-  isProduction && configuredApiBase?.startsWith('/')
-    ? apiProxyTarget
-    : configuredApiBase || (isProduction ? apiProxyTarget : '/api/proxy')
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
+
+const configuredApiBase = process.env.NEXT_PUBLIC_API_URL?.trim() || ''
+
+if (isProduction) {
+  if (!configuredApiBase) {
+    throw new Error('NEXT_PUBLIC_API_URL must be defined in production')
+  }
+
+  if (configuredApiBase.startsWith('/')) {
+    throw new Error('NEXT_PUBLIC_API_URL must be an absolute URL in production')
+  }
+}
+
+const apiBase = configuredApiBase || '/api/proxy'
+const apiProxyTarget = process.env.API_PROXY_TARGET?.trim() || ''
 const normalizedApiBase = apiBase.replace(/\/+$/, '')
-const normalizedApiProxyTarget = apiProxyTarget.replace(/\/+$/, '')
+const normalizedApiProxyTarget = trimTrailingSlash(apiProxyTarget)
 
 const nextConfig: NextConfig = {
   images: {
@@ -26,6 +35,10 @@ const nextConfig: NextConfig = {
   },
   async rewrites() {
     if (!normalizedApiBase.startsWith('/')) {
+      return []
+    }
+
+    if (!normalizedApiProxyTarget) {
       return []
     }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import { GetPublicPostsResponse } from '@/entities/users/api/api.types'
 import { Public } from '@/entities/users/ui'
-import { ApiErrorBoundary } from '@/lib/ApiErrorBoundary'
-import { apiFetch, ApiError } from '@/lib/api'
+import { apiFetch } from '@/lib/api'
 import { API_ROUTES } from '@/shared/api'
 import { buildApiUrl } from '@/shared/api/get-api-base-url'
 
@@ -23,11 +22,12 @@ const fetchPublicPostsForSSR = async () => {
 
 export default async function HomePage() {
   const { data, error } = await fetchPublicPostsForSSR()
-  const apiError: ApiError | null = error || null
 
-  return (
-    <ApiErrorBoundary error={apiError}>
-      {data ? <Public postsData={data} /> : <div>Данные отсутствуют</div>}
-    </ApiErrorBoundary>
-  )
+  // Avoid baking transient network errors into static HTML during build/ISR.
+  // When SSR fetch fails, client-side query in <Public /> will retry after hydration.
+  if (error || !data) {
+    return <Public />
+  }
+
+  return <Public postsData={data} />
 }

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { PaginatedPosts } from '@/entities/posts/api'
 import type { PostOpenSource } from '@/shared/constant'
 
 import { fetchPostByIdForSSR, fetchUserPosts } from '@/entities/posts/lib'
@@ -24,40 +25,87 @@ const isPostSource = (value: string): value is PostOpenSource => {
   return value === 'home' || value === 'profile' || value === 'direct'
 }
 
+const getErrorStatus = (error: unknown) => {
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = (error as { status?: unknown }).status
+
+    return typeof status === 'number' ? status : null
+  }
+
+  return null
+}
+
+const getEmptyPosts = (pageSize: number): PaginatedPosts => ({
+  items: [],
+  totalCount: 0,
+  pageSize,
+})
+
 export default async function ProfilePage({ params, searchParams }: Props) {
   const { id } = await params
   const query = await searchParams
   const userId = Number(id)
   const pageSize = 8
-  const postIdRaw = getSingleSearchParam(query.postId)
-  const parsedPostId = postIdRaw ? Number(postIdRaw) : NaN
-  const postId = Number.isInteger(parsedPostId) && parsedPostId > 0 ? parsedPostId : null
-  const sourceRaw = getSingleSearchParam(query.from)
-  const source = sourceRaw && isPostSource(sourceRaw) ? sourceRaw : 'direct'
 
-  try {
-    const [profileData, postsData, initialPostDataServer] = await Promise.all([
-      fetchProfileData(userId),
-      fetchUserPosts(userId, pageSize),
-      postId ? fetchPostByIdForSSR(postId) : Promise.resolve(null),
-    ])
-
-    return (
-      <Profile
-        profileDataServer={profileData}
-        postsDataServer={postsData}
-        initialPostIdServer={postId}
-        initialPostDataServer={initialPostDataServer}
-        initialPostSourceServer={source}
-      />
-    )
-  } catch (error) {
-    console.error('Error fetching profile or posts data:', error)
-
+  if (!Number.isInteger(userId) || userId <= 0) {
     return (
       <div>
         <h1>Profile not found</h1>
       </div>
     )
   }
+
+  const postIdRaw = getSingleSearchParam(query.postId)
+  const parsedPostId = postIdRaw ? Number(postIdRaw) : NaN
+  const postId = Number.isInteger(parsedPostId) && parsedPostId > 0 ? parsedPostId : null
+  const sourceRaw = getSingleSearchParam(query.from)
+  const source = sourceRaw && isPostSource(sourceRaw) ? sourceRaw : 'direct'
+
+  const [profileResult, postsResult, initialPostResult] = await Promise.allSettled([
+    fetchProfileData(userId),
+    fetchUserPosts(userId, pageSize),
+    postId ? fetchPostByIdForSSR(postId) : Promise.resolve(null),
+  ])
+
+  if (profileResult.status === 'rejected') {
+    console.error('Error fetching profile data:', profileResult.reason)
+    const status = getErrorStatus(profileResult.reason)
+
+    if (status === 404) {
+      return (
+        <div>
+          <h1>Profile not found</h1>
+        </div>
+      )
+    }
+
+    return (
+      <div>
+        <h1>Server unavailable</h1>
+        <p>Please try again later.</p>
+      </div>
+    )
+  }
+
+  if (postsResult.status === 'rejected') {
+    console.error('Error fetching profile posts data:', postsResult.reason)
+  }
+
+  if (initialPostResult.status === 'rejected') {
+    console.error('Error fetching initial post data:', initialPostResult.reason)
+  }
+
+  const postsData = postsResult.status === 'fulfilled' ? postsResult.value : getEmptyPosts(pageSize)
+  const initialPostDataServer =
+    initialPostResult.status === 'fulfilled' ? initialPostResult.value : null
+
+  return (
+    <Profile
+      profileDataServer={profileResult.value}
+      postsDataServer={postsData}
+      initialPostIdServer={postId}
+      initialPostDataServer={initialPostDataServer}
+      initialPostSourceServer={source}
+    />
+  )
 }

--- a/src/entities/posts/lib/posts-queries.ts
+++ b/src/entities/posts/lib/posts-queries.ts
@@ -4,15 +4,26 @@ import { buildApiUrl } from '@/shared/api/get-api-base-url'
 import { PaginatedPosts, PostViewModel } from '../api'
 
 async function fetchUserPosts(userId: number, pageSize: number): Promise<PaginatedPosts> {
-  const response = await fetch(
+  const privateResponse = await fetch(
     `${buildApiUrl(API_ROUTES.POSTS.USER_POSTS(userId, 0))}?pageSize=${pageSize}`
   )
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch user posts')
+  if (privateResponse.ok) {
+    return privateResponse.json()
   }
 
-  return response.json()
+  // SSR can be executed without auth context; fallback to public posts endpoint.
+  if (privateResponse.status === 401 || privateResponse.status === 403) {
+    const publicResponse = await fetch(
+      `${buildApiUrl(API_ROUTES.PUBLIC_POSTS.USER(userId, 0))}?pageSize=${pageSize}`
+    )
+
+    if (publicResponse.ok) {
+      return publicResponse.json()
+    }
+  }
+
+  throw new Error('Failed to fetch user posts')
 }
 
 const fetchPostByRoute = async (
@@ -40,7 +51,7 @@ async function fetchPostByIdForSSR(postId: number): Promise<PostViewModel | null
     return privatePostResult.post
   }
 
-  if (privatePostResult.status === 401) {
+  if (privatePostResult.status === 401 || privatePostResult.status === 403) {
     const publicPostResult = await fetchPostByRoute(API_ROUTES.PUBLIC_POSTS.BY_ID(postId))
 
     return publicPostResult.post

--- a/src/entities/profile/lib/profile-queries.ts
+++ b/src/entities/profile/lib/profile-queries.ts
@@ -3,11 +3,31 @@ import { buildApiUrl } from '@/shared/api/get-api-base-url'
 
 import { PublicProfileData } from '../api'
 
+type HttpStatusError = Error & {
+  status?: number
+}
+
+const createHttpStatusError = (message: string, status?: number): HttpStatusError => {
+  const error = new Error(message) as HttpStatusError
+
+  if (typeof status === 'number') {
+    error.status = status
+  }
+
+  return error
+}
+
 async function fetchProfileData(userId: number): Promise<PublicProfileData> {
-  const response = await fetch(buildApiUrl(API_ROUTES.PUBLIC_USER.PROFILE(userId)))
+  let response: Response
+
+  try {
+    response = await fetch(buildApiUrl(API_ROUTES.PUBLIC_USER.PROFILE(userId)))
+  } catch {
+    throw createHttpStatusError('Failed to fetch profile data')
+  }
 
   if (!response.ok) {
-    throw new Error('Failed to fetch profile data')
+    throw createHttpStatusError('Failed to fetch profile data', response.status)
   }
 
   return response.json()

--- a/src/entities/users/ui/public/Public.tsx
+++ b/src/entities/users/ui/public/Public.tsx
@@ -15,7 +15,7 @@ import { PublicPost } from './PublicPost/PublicPost'
 import { UsersCounter } from './UsersCounter/UsersCounter'
 
 type Props = {
-  postsData: GetPublicPostsResponse
+  postsData?: GetPublicPostsResponse
 }
 
 const LCP_PRIORITY_POSTS_COUNT = 1

--- a/src/shared/api/get-api-base-url.ts
+++ b/src/shared/api/get-api-base-url.ts
@@ -1,5 +1,4 @@
 const DEFAULT_DEV_API_BASE = '/api/proxy'
-const DEFAULT_API_TARGET = 'https://ictroot.uk/api'
 const DEFAULT_INTERNAL_ORIGIN = 'http://localhost:3000'
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -7,12 +6,27 @@ const isAbsoluteUrl = (value: string) => /^https?:\/\//.test(value)
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '')
 const ensureLeadingSlash = (value: string) => (value.startsWith('/') ? value : `/${value}`)
 
+const getRequiredProductionApiBase = () => {
+  const configuredBase = trimTrailingSlash(process.env.NEXT_PUBLIC_API_URL?.trim() || '')
+
+  if (!configuredBase) {
+    throw new Error('NEXT_PUBLIC_API_URL must be defined in production')
+  }
+
+  if (!isAbsoluteUrl(configuredBase)) {
+    throw new Error('NEXT_PUBLIC_API_URL must be an absolute URL in production')
+  }
+
+  return configuredBase
+}
+
 export const getApiBaseUrl = () => {
-  const configuredBase =
-    process.env.NEXT_PUBLIC_API_URL || (isProduction ? DEFAULT_API_TARGET : DEFAULT_DEV_API_BASE)
-  const normalizedBase = trimTrailingSlash(configuredBase)
-  const effectiveBase =
-    isProduction && normalizedBase.startsWith('/') ? DEFAULT_API_TARGET : normalizedBase
+  if (isProduction) {
+    return getRequiredProductionApiBase()
+  }
+
+  const configuredBase = process.env.NEXT_PUBLIC_API_URL?.trim() || DEFAULT_DEV_API_BASE
+  const effectiveBase = trimTrailingSlash(configuredBase)
 
   if (isAbsoluteUrl(effectiveBase)) {
     return effectiveBase
@@ -23,7 +37,7 @@ export const getApiBaseUrl = () => {
   }
 
   if (effectiveBase.startsWith('/')) {
-    const apiProxyTarget = trimTrailingSlash(process.env.API_PROXY_TARGET || DEFAULT_API_TARGET)
+    const apiProxyTarget = trimTrailingSlash(process.env.API_PROXY_TARGET?.trim() || '')
 
     if (apiProxyTarget) {
       return apiProxyTarget


### PR DESCRIPTION
## Summary

- Jira: T4 / Hotfix profile SSR error classification
- What changed:
  - Fixed false `Profile not found` on SSR profile page.
  - Separated error handling by type/status (`404` vs transient/network/server errors).
  - Added SSR fallback for posts/private post fetch (`401/403` -> public endpoint).
  - Added governance checks to prevent “baked” error UI in SSR/ISR flows.

## Scope

### In scope

- `src/app/profile/[id]/page.tsx`
- `src/entities/posts/lib/posts-queries.ts`
- `src/entities/profile/lib/profile-queries.ts`
- `.ai/anti-patterns.md`
- `.ai/quality-gates.md`
- `.ai/playbooks/pr-review.md`

### Out of scope

- Docker/Jenkins pipeline changes
- Policy version update (`.ai/policy.md`)
- Payments/subscriptions flow changes

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

## Contract change

- What changed: N/A
- Why: N/A
- Impact/Migration: N/A
- Policy version updated: N/A

## Mandatory checklist

- [ ] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
  - `pnpm typecheck` — pass
  - `pnpm build` — pass in local env with reachable network
  - `pnpm run ci:check` — run required in target env before merge

### Manual

- Scenario 1: Open existing own profile (`/profile/<myId>`) -> profile renders, no false `Profile not found`.
- Scenario 2: Open existing чужой профиль (`/profile/<existingUserId>`) -> profile renders.
- Scenario 3: Open non-existing profile id -> `Profile not found`.
- Scenario 4: Simulate transient API failure -> `Server unavailable` (not `Profile not found`).

## Risks and Rollback

- Risks:
  - SSR fallback behavior now depends on status-based branching; unexpected backend status mapping may affect displayed state.
- Rollback plan:
  - Revert commits:
    - `86aa30c`
    - `3a89b14`
  - Re-run `pnpm run ci:check` and redeploy.
