### PR TITLE
fix(ssr): restore profile/post rendering and align public feed contract

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ const PUBLIC_SSR_REVALIDATE_SECONDS = 60
 export const revalidate = 60
 
 const fetchPublicPostsForSSR = async () => {
-  const url = `${buildApiUrl(API_ROUTES.PUBLIC_POSTS.ALL(INITIAL_PUBLIC_POST_CURSOR))}?pageSize=${PUBLIC_POSTS_PAGE_SIZE}`
+  const url = `${buildApiUrl(API_ROUTES.POSTS.ALL(INITIAL_PUBLIC_POST_CURSOR))}?pageSize=${PUBLIC_POSTS_PAGE_SIZE}`
 
   return apiFetch<GetPublicPostsResponse>(url, {
     next: {

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { PaginatedPosts } from '@/entities/posts/api'
 import type { PostOpenSource } from '@/shared/constant'
 
 import { fetchPostByIdForSSR, fetchUserPosts } from '@/entities/posts/lib'
@@ -24,40 +25,90 @@ const isPostSource = (value: string): value is PostOpenSource => {
   return value === 'home' || value === 'profile' || value === 'direct'
 }
 
+const getErrorStatus = (error: unknown) => {
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = (error as { status?: unknown }).status
+
+    return typeof status === 'number' ? status : null
+  }
+
+  return null
+}
+
+const getEmptyPosts = (pageSize: number): PaginatedPosts => ({
+  items: [],
+  totalCount: 0,
+  pageSize,
+})
+
 export default async function ProfilePage({ params, searchParams }: Props) {
   const { id } = await params
   const query = await searchParams
   const userId = Number(id)
   const pageSize = 8
-  const postIdRaw = getSingleSearchParam(query.postId)
-  const parsedPostId = postIdRaw ? Number(postIdRaw) : NaN
-  const postId = Number.isInteger(parsedPostId) && parsedPostId > 0 ? parsedPostId : null
-  const sourceRaw = getSingleSearchParam(query.from)
-  const source = sourceRaw && isPostSource(sourceRaw) ? sourceRaw : 'direct'
 
-  try {
-    const [profileData, postsData, initialPostDataServer] = await Promise.all([
-      fetchProfileData(userId),
-      fetchUserPosts(userId, pageSize),
-      postId ? fetchPostByIdForSSR(postId) : Promise.resolve(null),
-    ])
-
-    return (
-      <Profile
-        profileDataServer={profileData}
-        postsDataServer={postsData}
-        initialPostIdServer={postId}
-        initialPostDataServer={initialPostDataServer}
-        initialPostSourceServer={source}
-      />
-    )
-  } catch (error) {
-    console.error('Error fetching profile or posts data:', error)
-
+  if (!Number.isInteger(userId) || userId <= 0) {
     return (
       <div>
         <h1>Profile not found</h1>
       </div>
     )
   }
+
+  const postIdRaw = getSingleSearchParam(query.postId)
+  const parsedPostId = postIdRaw ? Number(postIdRaw) : NaN
+  const postId = Number.isInteger(parsedPostId) && parsedPostId > 0 ? parsedPostId : null
+  const sourceRaw = getSingleSearchParam(query.from)
+  const source = sourceRaw && isPostSource(sourceRaw) ? sourceRaw : 'direct'
+
+  let profileDataServer
+
+  try {
+    profileDataServer = await fetchProfileData(userId)
+  } catch (error) {
+    console.error('Error fetching profile data:', error)
+    const status = getErrorStatus(error)
+
+    if (status === 404) {
+      return (
+        <div>
+          <h1>Profile not found</h1>
+        </div>
+      )
+    }
+
+    return (
+      <div>
+        <h1>Server unavailable</h1>
+        <p>Please try again later.</p>
+      </div>
+    )
+  }
+
+  const [postsResult, initialPostResult] = await Promise.allSettled([
+    fetchUserPosts(userId, pageSize, profileDataServer.userName),
+    postId ? fetchPostByIdForSSR(postId) : Promise.resolve(null),
+  ])
+
+  if (postsResult.status === 'rejected') {
+    console.error('Error fetching profile posts data:', postsResult.reason)
+  }
+
+  if (initialPostResult.status === 'rejected') {
+    console.error('Error fetching initial post data:', initialPostResult.reason)
+  }
+
+  const postsData = postsResult.status === 'fulfilled' ? postsResult.value : getEmptyPosts(pageSize)
+  const initialPostDataServer =
+    initialPostResult.status === 'fulfilled' ? initialPostResult.value : null
+
+  return (
+    <Profile
+      profileDataServer={profileDataServer}
+      postsDataServer={postsData}
+      initialPostIdServer={postId}
+      initialPostDataServer={initialPostDataServer}
+      initialPostSourceServer={source}
+    />
+  )
 }

--- a/src/entities/posts/lib/posts-queries.ts
+++ b/src/entities/posts/lib/posts-queries.ts
@@ -3,16 +3,149 @@ import { buildApiUrl } from '@/shared/api/get-api-base-url'
 
 import { PaginatedPosts, PostViewModel } from '../api'
 
-async function fetchUserPosts(userId: number, pageSize: number): Promise<PaginatedPosts> {
-  const response = await fetch(
-    `${buildApiUrl(API_ROUTES.POSTS.USER_POSTS(userId, 0))}?pageSize=${pageSize}`
-  )
+const buildRouteUrl = (route: string, query?: Record<string, number | string>) => {
+  const searchParams = new URLSearchParams()
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch user posts')
+  if (query) {
+    Object.entries(query).forEach(([key, value]) => {
+      searchParams.set(key, String(value))
+    })
   }
 
-  return response.json()
+  const serializedQuery = searchParams.toString()
+
+  return serializedQuery ? `${buildApiUrl(route)}?${serializedQuery}` : buildApiUrl(route)
+}
+
+const normalizePaginatedPosts = (
+  value: unknown,
+  fallbackPageSize: number
+): null | PaginatedPosts => {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const raw = value as {
+    items?: unknown
+    pageSize?: unknown
+    totalCount?: unknown
+  }
+
+  if (!Array.isArray(raw.items)) {
+    return null
+  }
+
+  return {
+    items: raw.items as PostViewModel[],
+    pageSize: typeof raw.pageSize === 'number' ? raw.pageSize : fallbackPageSize,
+    totalCount: typeof raw.totalCount === 'number' ? raw.totalCount : raw.items.length,
+  }
+}
+
+const fetchPaginatedPostsByRoute = async ({
+  route,
+  pageSize,
+  query,
+}: {
+  route: string
+  pageSize: number
+  query?: Record<string, number | string>
+}): Promise<{ data: null | PaginatedPosts; status: null | number }> => {
+  try {
+    const response = await fetch(buildRouteUrl(route, query))
+
+    if (!response.ok) {
+      return { data: null, status: response.status }
+    }
+
+    const normalized = normalizePaginatedPosts(await response.json(), pageSize)
+
+    if (!normalized) {
+      return { data: null, status: response.status }
+    }
+
+    return { data: normalized, status: response.status }
+  } catch (error) {
+    console.error('Error fetching paginated posts by route:', error)
+
+    return { data: null, status: null }
+  }
+}
+
+const fetchPostByParamRoute = async (postId: number): Promise<null | PostViewModel> => {
+  try {
+    const response = await fetch(
+      buildRouteUrl(API_ROUTES.POSTS.PARAM(String(postId)), {
+        pageNumber: 1,
+        pageSize: 1,
+        sortDirection: 'desc',
+      })
+    )
+
+    if (!response.ok) {
+      return null
+    }
+
+    const payload = (await response.json()) as { items?: PostViewModel[] }
+
+    if (!Array.isArray(payload.items)) {
+      return null
+    }
+
+    return payload.items.find(item => item.id === postId) || null
+  } catch (error) {
+    console.error('Error fetching post by param route:', error)
+
+    return null
+  }
+}
+
+async function fetchUserPosts(
+  userId: number,
+  pageSize: number,
+  profileUserName?: string
+): Promise<PaginatedPosts> {
+  const privateResult = await fetchPaginatedPostsByRoute({
+    route: API_ROUTES.POSTS.USER_POSTS(userId, 0),
+    pageSize,
+    query: { pageSize },
+  })
+
+  if (privateResult.data) {
+    return privateResult.data
+  }
+
+  // SSR может выполняться без auth-контекста: сначала пробуем legacy public endpoint.
+  if (
+    privateResult.status === 401 ||
+    privateResult.status === 403 ||
+    privateResult.status === 404
+  ) {
+    const legacyPublicResult = await fetchPaginatedPostsByRoute({
+      route: API_ROUTES.PUBLIC_POSTS.USER(userId, 0),
+      pageSize,
+      query: { pageSize },
+    })
+
+    if (legacyPublicResult.data) {
+      return legacyPublicResult.data
+    }
+  }
+
+  // Fallback for backends where public-posts endpoints are removed in favor of /posts/{param}.
+  if (profileUserName) {
+    const byUsernameResult = await fetchPaginatedPostsByRoute({
+      route: API_ROUTES.POSTS.PARAM(encodeURIComponent(profileUserName)),
+      pageSize,
+      query: { pageNumber: 1, pageSize, sortDirection: 'desc' },
+    })
+
+    if (byUsernameResult.data) {
+      return byUsernameResult.data
+    }
+  }
+
+  throw new Error('Failed to fetch user posts')
 }
 
 const fetchPostByRoute = async (
@@ -40,13 +173,15 @@ async function fetchPostByIdForSSR(postId: number): Promise<PostViewModel | null
     return privatePostResult.post
   }
 
-  if (privatePostResult.status === 401) {
+  if (privatePostResult.status === 401 || privatePostResult.status === 403) {
     const publicPostResult = await fetchPostByRoute(API_ROUTES.PUBLIC_POSTS.BY_ID(postId))
 
-    return publicPostResult.post
+    if (publicPostResult.post) {
+      return publicPostResult.post
+    }
   }
 
-  return null
+  return fetchPostByParamRoute(postId)
 }
 
 export { fetchUserPosts, fetchPostByIdForSSR }

--- a/src/entities/profile/lib/profile-queries.ts
+++ b/src/entities/profile/lib/profile-queries.ts
@@ -3,11 +3,31 @@ import { buildApiUrl } from '@/shared/api/get-api-base-url'
 
 import { PublicProfileData } from '../api'
 
+type HttpStatusError = Error & {
+  status?: number
+}
+
+const createHttpStatusError = (message: string, status?: number): HttpStatusError => {
+  const error = new Error(message) as HttpStatusError
+
+  if (typeof status === 'number') {
+    error.status = status
+  }
+
+  return error
+}
+
 async function fetchProfileData(userId: number): Promise<PublicProfileData> {
-  const response = await fetch(buildApiUrl(API_ROUTES.PUBLIC_USER.PROFILE(userId)))
+  let response: Response
+
+  try {
+    response = await fetch(buildApiUrl(API_ROUTES.PUBLIC_USER.PROFILE(userId)))
+  } catch {
+    throw createHttpStatusError('Failed to fetch profile data')
+  }
 
   if (!response.ok) {
-    throw new Error('Failed to fetch profile data')
+    throw createHttpStatusError('Failed to fetch profile data', response.status)
   }
 
   return response.json()

--- a/src/entities/profile/ui/Profile/ProfilePosts/ProfilePosts.tsx
+++ b/src/entities/profile/ui/Profile/ProfilePosts/ProfilePosts.tsx
@@ -120,16 +120,7 @@ export const ProfilePosts: React.FC<Props> = ({
 
     router.replace(APP_ROUTES.PROFILE.ID(userId), { scroll: false })
   }
-
-  if (!posts?.length) {
-    return (
-      <Typography variant={'h1'} className={s.message}>
-        {isOwnProfile
-          ? "You haven't published any posts yet"
-          : "This user hasn't published any posts yet"}
-      </Typography>
-    )
-  }
+  const hasPosts = Boolean(posts?.length)
 
   return (
     <div className={s.wrapper}>
@@ -139,11 +130,19 @@ export const ProfilePosts: React.FC<Props> = ({
           onChange={handleModalStateFromUrl}
         />
       </Suspense>
-      <ul className={s.posts}>
-        {posts.map(post => (
-          <PostCard key={post.id} post={post} />
-        ))}
-      </ul>
+      {hasPosts ? (
+        <ul className={s.posts}>
+          {posts.map(post => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </ul>
+      ) : (
+        <Typography variant={'h1'} className={s.message}>
+          {isOwnProfile
+            ? "You haven't published any posts yet"
+            : "This user hasn't published any posts yet"}
+        </Typography>
+      )}
 
       {isPostModalOpen && (
         <>

--- a/src/entities/users/api/publicUsers.api.ts
+++ b/src/entities/users/api/publicUsers.api.ts
@@ -12,9 +12,9 @@ export const publicUsersApi = baseApi.injectEndpoints({
       }),
     }),
     getPublicPosts: builder.query<GetPublicPostsResponse, GetPublicPostsRequest>({
-      query: ({ endCursorPostId, ...params }) => ({
+      query: ({ endCursorPostId = 0, ...params }) => ({
         params,
-        url: `v1/public-posts/all/${endCursorPostId}`,
+        url: API_ROUTES.POSTS.ALL(endCursorPostId),
       }),
     }),
   }),

--- a/src/shared/api/api-routes.ts
+++ b/src/shared/api/api-routes.ts
@@ -37,6 +37,7 @@ export const API_ROUTES = {
 
   POSTS: {
     BASE: '/v1/posts',
+    ALL: (endCursorPostId: number) => `/v1/posts/all/${endCursorPostId}`,
     BY_ID: (postId: number) => `/v1/posts/id/${postId}`,
     IMAGE: '/v1/posts/image',
     DELETE_IMAGE: (uploadId: string) => `/v1/posts/image/${uploadId}`,


### PR DESCRIPTION
## Summary

- Jira: N/A (hotfix SSR/profile/post regression after rollback)
- What changed:
  - Восстановили корректный SSR-поток профиля: ошибки профиля больше не маскируются как `Profile not found` для всех случаев.
  - Добавили устойчивые fallback-и для SSR постов/профиля:
    - private `/v1/posts/user/...` -> legacy `/v1/public-posts/user/...` -> `/v1/posts/{username}`.
    - private `/v1/posts/id/{postId}` -> legacy `/v1/public-posts/{postId}` -> `/v1/posts/{postId}` (через param-route).
  - Исправили кейс, когда modal post не открывался при пустом списке постов на профиле.
  - Синхронизировали public feed с актуальным контрактом: main/public posts теперь через `/v1/posts/all/{endCursorPostId}`.

## Scope

### In scope

- `src/app/profile/[id]/page.tsx`
- `src/entities/posts/lib/posts-queries.ts`
- `src/entities/profile/lib/profile-queries.ts`
- `src/entities/profile/ui/Profile/ProfilePosts/ProfilePosts.tsx`
- `src/app/page.tsx`
- `src/entities/users/api/publicUsers.api.ts`
- `src/shared/api/api-routes.ts`

### Out of scope

- Jenkinsfile / Dockerfile / deployment manifests
- Изменения бизнес-логики create/edit/delete post
- Рефакторинг не связанных модулей

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

## Contract change

- What changed: Использование `/v1/posts/all/...` для public feed + fallback-совместимость со старыми `public-posts` endpoint.
- Why: После отката ветки и разных backend-окружений возник рассинхрон контрактов, что ломало SSR/profile/post modal.
- Impact/Migration: Миграция не требуется; добавлена backward compatibility на FE.
- Policy version updated: N/A

## Mandatory checklist

- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
  - `pnpm eslint ...` (changed files) -> pass
  - `pnpm typecheck` -> pass
  - `pnpm run ci:check` -> pass

### Manual

- Scenario 1:
  - Открыть `/profile/{existingId}` в неавторизованном режиме.
  - Ожидание: профиль рендерится SSR, без ложного `Profile not found`.
- Scenario 2:
  - Открыть `/profile/{existingId}?postId={existingPostId}&from=profile`.
  - Ожидание: модальное окно поста открывается, закрытие возвращает на профиль.
- Scenario 3:
  - С главной открыть пост (`from=home`) и закрыть.
  - Ожидание: возврат на `/`, без `Server unavailable` при валидных данных.

## Risks and Rollback

- Risks:
  - Backend может по-разному поддерживать legacy `public-posts` и новый `posts` контракт; покрыто fallback-цепочкой, но требует smoke после деплоя.
- Rollback plan:
  - Revert commit `b50487c` в случае регрессии.
  - Либо откат ветки на предыдущий стабильный commit перед этим hotfix.
