### PR TITLE
fix(profile): add SSR recovery for profile route and post modal loading

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -4,6 +4,7 @@ import type { PostOpenSource } from '@/shared/constant'
 import { fetchPostByIdForSSR, fetchUserPosts } from '@/entities/posts/lib'
 import { fetchProfileData } from '@/entities/profile/lib'
 import { Profile } from '@/entities/profile/ui'
+import { ProfileClientRecovery } from '@/entities/profile/ui/Profile/ProfileClientRecovery'
 
 type Props = {
   params: Promise<{ id: string }>
@@ -40,6 +41,8 @@ const getEmptyPosts = (pageSize: number): PaginatedPosts => ({
   totalCount: 0,
   pageSize,
 })
+
+export const dynamic = 'force-dynamic'
 
 export default async function ProfilePage({ params, searchParams }: Props) {
   const { id } = await params
@@ -78,10 +81,7 @@ export default async function ProfilePage({ params, searchParams }: Props) {
     }
 
     return (
-      <div>
-        <h1>Server unavailable</h1>
-        <p>Please try again later.</p>
-      </div>
+      <ProfileClientRecovery userId={userId} initialPostId={postId} initialPostSource={source} />
     )
   }
 

--- a/src/entities/posts/lib/posts-queries.ts
+++ b/src/entities/posts/lib/posts-queries.ts
@@ -3,6 +3,8 @@ import { buildApiUrl } from '@/shared/api/get-api-base-url'
 
 import { PaginatedPosts, PostViewModel } from '../api'
 
+const REQUEST_OPTIONS = { cache: 'no-store' as const }
+
 const buildRouteUrl = (route: string, query?: Record<string, number | string>) => {
   const searchParams = new URLSearchParams()
 
@@ -52,7 +54,7 @@ const fetchPaginatedPostsByRoute = async ({
   query?: Record<string, number | string>
 }): Promise<{ data: null | PaginatedPosts; status: null | number }> => {
   try {
-    const response = await fetch(buildRouteUrl(route, query))
+    const response = await fetch(buildRouteUrl(route, query), REQUEST_OPTIONS)
 
     if (!response.ok) {
       return { data: null, status: response.status }
@@ -79,7 +81,8 @@ const fetchPostByParamRoute = async (postId: number): Promise<null | PostViewMod
         pageNumber: 1,
         pageSize: 1,
         sortDirection: 'desc',
-      })
+      }),
+      REQUEST_OPTIONS
     )
 
     if (!response.ok) {
@@ -152,7 +155,7 @@ const fetchPostByRoute = async (
   route: string
 ): Promise<{ post: PostViewModel | null; status: null | number }> => {
   try {
-    const response = await fetch(buildApiUrl(route))
+    const response = await fetch(buildApiUrl(route), REQUEST_OPTIONS)
 
     if (!response.ok) {
       return { post: null, status: response.status }

--- a/src/entities/profile/lib/profile-queries.ts
+++ b/src/entities/profile/lib/profile-queries.ts
@@ -17,11 +17,13 @@ const createHttpStatusError = (message: string, status?: number): HttpStatusErro
   return error
 }
 
+const REQUEST_OPTIONS = { cache: 'no-store' as const }
+
 async function fetchProfileData(userId: number): Promise<PublicProfileData> {
   let response: Response
 
   try {
-    response = await fetch(buildApiUrl(API_ROUTES.PUBLIC_USER.PROFILE(userId)))
+    response = await fetch(buildApiUrl(API_ROUTES.PUBLIC_USER.PROFILE(userId)), REQUEST_OPTIONS)
   } catch {
     throw createHttpStatusError('Failed to fetch profile data')
   }

--- a/src/entities/profile/ui/Profile/ProfileClientRecovery.tsx
+++ b/src/entities/profile/ui/Profile/ProfileClientRecovery.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { type PaginatedPosts, type PostViewModel } from '@/entities/posts/api'
+import { fetchPostByIdForSSR, fetchUserPosts } from '@/entities/posts/lib'
+import { type PublicProfileData } from '@/entities/profile/api'
+import { fetchProfileData } from '@/entities/profile/lib'
+import { Loading } from '@/shared/composites'
+import { type PostOpenSource } from '@/shared/constant'
+
+import { Profile } from './Profile'
+
+type Props = {
+  initialPostId: null | number
+  initialPostSource: PostOpenSource
+  userId: number
+}
+
+type RecoveryState =
+  | { status: 'error' }
+  | { status: 'loading' }
+  | { status: 'not_found' }
+  | {
+      initialPostData: null | PostViewModel
+      postsData: PaginatedPosts
+      profileData: PublicProfileData
+      status: 'ready'
+    }
+
+const PAGE_SIZE = 8
+
+const EMPTY_POSTS: PaginatedPosts = {
+  items: [],
+  pageSize: PAGE_SIZE,
+  totalCount: 0,
+}
+
+const getErrorStatus = (error: unknown) => {
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = (error as { status?: unknown }).status
+
+    return typeof status === 'number' ? status : null
+  }
+
+  return null
+}
+
+export function ProfileClientRecovery({ userId, initialPostId, initialPostSource }: Props) {
+  const [state, setState] = useState<RecoveryState>({ status: 'loading' })
+
+  useEffect(() => {
+    let isMounted = true
+
+    const load = async () => {
+      setState({ status: 'loading' })
+
+      let profileData: PublicProfileData
+
+      try {
+        profileData = await fetchProfileData(userId)
+      } catch (error) {
+        if (!isMounted) {
+          return
+        }
+
+        const status = getErrorStatus(error)
+
+        if (status === 404) {
+          setState({ status: 'not_found' })
+
+          return
+        }
+
+        setState({ status: 'error' })
+
+        return
+      }
+
+      const [postsResult, initialPostResult] = await Promise.allSettled([
+        fetchUserPosts(userId, PAGE_SIZE, profileData.userName),
+        initialPostId ? fetchPostByIdForSSR(initialPostId) : Promise.resolve(null),
+      ])
+
+      if (!isMounted) {
+        return
+      }
+
+      setState({
+        initialPostData: initialPostResult.status === 'fulfilled' ? initialPostResult.value : null,
+        postsData: postsResult.status === 'fulfilled' ? postsResult.value : EMPTY_POSTS,
+        profileData,
+        status: 'ready',
+      })
+    }
+
+    void load()
+
+    return () => {
+      isMounted = false
+    }
+  }, [initialPostId, userId])
+
+  if (state.status === 'loading') {
+    return <Loading />
+  }
+
+  if (state.status === 'not_found') {
+    return (
+      <div>
+        <h1>Profile not found</h1>
+      </div>
+    )
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div>
+        <h1>Server unavailable</h1>
+        <p>Please try again later.</p>
+      </div>
+    )
+  }
+
+  return (
+    <Profile
+      profileDataServer={state.profileData}
+      postsDataServer={state.postsData}
+      initialPostIdServer={initialPostId}
+      initialPostDataServer={state.initialPostData}
+      initialPostSourceServer={initialPostSource}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- Jira: N/A 
- What changed:
  - Добавлен recovery-путь для `/profile/[id]`: при server-side ошибке страница не падает в dead-end, а делает client-side восстановление данных профиля/постов.
  - Добавлен `ProfileClientRecovery` для повторной загрузки профиля, постов и initial post.
  - Для SSR-запросов профиля и постов добавлен `cache: 'no-store'`, чтобы исключить кешированный fallback/устаревшие ответы.
  - Для страницы профиля включен `dynamic = 'force-dynamic'`.

## Scope

### In scope

- Поведение роута профиля `/profile/[id]` при ошибках SSR.
- Открытие поста из профиля/по прямой ссылке через устойчивый fallback.
- Политика кеширования server fetch для профиля и постов.

### Out of scope

- Docker/Jenkins/Kubernetes/CI pipeline.
- Изменения API backend.
- Рефакторинг других роутов.

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

If architectural change is checked:

- add label `policy-change`
- fill `Contract change` section
- update `.ai/policy.md` version metadata

## Contract change

- What changed: N/A
- Why: N/A
- Impact/Migration: N/A
- Policy version updated: N/A

## Mandatory checklist

- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
  - `pnpm run ci:check` ✅ passed (lint/typecheck/build completed)

### Manual

- Scenario 1: Открыть `/profile/{id}` для существующего пользователя → профиль отображается, без `Server unavailable`.
- Scenario 2: Открыть пост из профиля или по URL `?postId=...` → модальное окно поста открывается корректно.

## Risks and Rollback

- Risks:
  - Возможна дополнительная клиентская догрузка при SSR-сбое (временное увеличение времени до отображения).
- Rollback plan:
  - Revert этого PR одним коммитом (`git revert <commit_sha>`) и повторный деплой.
