### PR TITLE
Hotfix/profile ssr diag

### DIFF
--- a/src/app/profile/[id]/page.module.scss
+++ b/src/app/profile/[id]/page.module.scss
@@ -1,0 +1,14 @@
+.debugBlock {
+  white-space: pre-wrap;
+}
+
+.ssrDebugBlock {
+  background: #fff3cd;
+  border: 1px solid #ffeeba;
+  color: #856404;
+  padding: 8px 12px;
+  margin: 8px;
+  white-space: pre-wrap;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -7,6 +7,8 @@ import { Profile } from '@/entities/profile/ui'
 import { logger } from '@/shared/lib/logger'
 import { getSsrFetchErrorStatus } from '@/shared/lib/ssr/safeSsrFetch'
 
+import s from './page.module.scss'
+
 type Props = {
   params: Promise<{ id: string }>
   searchParams: Promise<{
@@ -15,17 +17,32 @@ type Props = {
   }>
 }
 
-const getSingleSearchParam = (value?: string | string[]) => {
-  if (Array.isArray(value)) {
-    return value[0]
-  }
-
-  return value
+type SsrErrorDetails = {
+  bodyPreview: string
+  kind: string
+  message: string
+  status: null | number
+  url: string
 }
 
-const isPostSource = (value: string): value is PostOpenSource => {
-  return value === 'home' || value === 'profile' || value === 'direct'
+const PAGE_SIZE = 8
+
+const POST_SOURCES: ReadonlySet<PostOpenSource> = new Set(['home', 'profile', 'direct'])
+
+const getSingleSearchParam = (value?: string | string[]) =>
+  Array.isArray(value) ? value[0] : value
+
+const isPostSource = (value: string): value is PostOpenSource =>
+  POST_SOURCES.has(value as PostOpenSource)
+
+const parsePostId = (raw?: string) => {
+  const parsed = raw ? Number(raw) : Number.NaN
+
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
 }
+
+const parsePostSource = (raw?: string): PostOpenSource =>
+  raw && isPostSource(raw) ? raw : 'direct'
 
 const getEmptyPosts = (pageSize: number): PaginatedPosts => ({
   items: [],
@@ -33,63 +50,112 @@ const getEmptyPosts = (pageSize: number): PaginatedPosts => ({
   pageSize,
 })
 
-export const dynamic = 'force-dynamic'
-
-export default async function ProfilePage({ params, searchParams }: Props) {
-  const { id } = await params
-  const query = await searchParams
-  const userId = Number(id)
-  const pageSize = 8
-
-  if (!Number.isInteger(userId) || userId <= 0) {
-    return (
-      <div>
-        <h1>Profile not found</h1>
-      </div>
-    )
+const readErrorField = (error: unknown, field: string): unknown => {
+  if (typeof error === 'object' && error !== null && field in error) {
+    return (error as Record<string, unknown>)[field]
   }
 
-  const postIdRaw = getSingleSearchParam(query.postId)
-  const parsedPostId = postIdRaw ? Number(postIdRaw) : NaN
-  const postId = Number.isInteger(parsedPostId) && parsedPostId > 0 ? parsedPostId : null
-  const sourceRaw = getSingleSearchParam(query.from)
-  const source = sourceRaw && isPostSource(sourceRaw) ? sourceRaw : 'direct'
+  return undefined
+}
+
+const safeStringify = (value: unknown, fallback = ''): string => {
+  if (value === undefined || value === null) {
+    return fallback
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value)
+  }
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return fallback
+  }
+}
+
+const extractSsrErrorDetails = (error: unknown): SsrErrorDetails => ({
+  status: getSsrFetchErrorStatus(error),
+  kind: safeStringify(readErrorField(error, 'kind'), 'unknown'),
+  url: safeStringify(readErrorField(error, 'url')),
+  bodyPreview: safeStringify(readErrorField(error, 'bodyPreview')),
+  message: error instanceof Error ? error.message : 'Unknown error',
+})
+
+const formatDebugLine = (details: SsrErrorDetails) =>
+  `status: ${details.status ?? 'n/a'} | kind: ${details.kind}\nurl: ${details.url}\nmessage: ${details.message}${
+    details.bodyPreview ? `\nbodyPreview: ${details.bodyPreview}` : ''
+  }`
+
+const NotFoundView = ({ details }: { details?: SsrErrorDetails }) => (
+  <div>
+    <h1>Profile not found</h1>
+    {details ? (
+      <pre className={s.debugBlock} data-ssr-debug={'profile-not-found'}>
+        {formatDebugLine(details)}
+      </pre>
+    ) : null}
+  </div>
+)
+
+const ServerUnavailableView = ({ details }: { details: SsrErrorDetails }) => (
+  <div>
+    <h1>Server unavailable</h1>
+    <p>Please try again later.</p>
+    <pre className={s.ssrDebugBlock} data-ssr-debug={'ssr-catch'}>
+      {`[SSR debug] ${formatDebugLine(details)}`}
+    </pre>
+  </div>
+)
+
+const renderProfileError = (error: unknown, userId: number) => {
+  const details = extractSsrErrorDetails(error)
+
+  logger.error('[ProfilePage] fetchProfileData failed', {
+    userId,
+    status: details.status,
+    kind: details.kind,
+    url: details.url,
+    errorMessage: details.message,
+    bodyPreview: details.bodyPreview,
+  })
+
+  if (details.status === 404) {
+    return <NotFoundView details={details} />
+  }
+
+  return <ServerUnavailableView details={details} />
+}
+
+export const dynamic = 'force-dynamic'
+
+export default async function ProfilePage({ params, searchParams }: Readonly<Props>) {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const userId = Number(id)
+
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return <NotFoundView />
+  }
+
+  const initialPostId = parsePostId(getSingleSearchParam(query.postId))
+  const initialPostSource = parsePostSource(getSingleSearchParam(query.from))
 
   let profileDataServer
 
   try {
     profileDataServer = await fetchProfileData(userId)
   } catch (error) {
-    const status = getSsrFetchErrorStatus(error)
-
-    logger.error('[ProfilePage] fetchProfileData failed', {
-      status,
-      userId,
-      errorMessage: error instanceof Error ? error.message : 'Unknown error',
-    })
-
-    if (status === 404) {
-      return (
-        <div>
-          <h1>Profile not found</h1>
-        </div>
-      )
-    }
-
-    return (
-      <div>
-        <h1>Server unavailable</h1>
-        <p>Please try again later.</p>
-      </div>
-    )
+    return renderProfileError(error, userId)
   }
 
   const [postsResult, initialPostResult] = await Promise.allSettled([
-    fetchUserPosts(userId, pageSize, profileDataServer.userName),
-    postId ? fetchPostByIdForSSR(postId) : Promise.resolve(null),
+    fetchUserPosts(userId, PAGE_SIZE, profileDataServer.userName),
+    initialPostId ? fetchPostByIdForSSR(initialPostId) : Promise.resolve(null),
   ])
 
-  const postsData = postsResult.status === 'fulfilled' ? postsResult.value : getEmptyPosts(pageSize)
+  const postsData =
+    postsResult.status === 'fulfilled' ? postsResult.value : getEmptyPosts(PAGE_SIZE)
   const initialPostDataServer =
     initialPostResult.status === 'fulfilled' ? initialPostResult.value : null
 
@@ -97,9 +163,9 @@ export default async function ProfilePage({ params, searchParams }: Props) {
     <Profile
       profileDataServer={profileDataServer}
       postsDataServer={postsData}
-      initialPostIdServer={postId}
+      initialPostIdServer={initialPostId}
       initialPostDataServer={initialPostDataServer}
-      initialPostSourceServer={source}
+      initialPostSourceServer={initialPostSource}
     />
   )
 }


### PR DESCRIPTION
## Summary

- Jira: `SCRUM-???`
- What changed:
  - Add temporary, removable diagnostics on `/profile/[id]` to surface real SSR/client fetch error details (status / kind / url / message / bodyPreview) in production.
  - SSR catch path renders an inline `[SSR debug]` block above `ProfileClientRecovery` instead of swallowing the error.
  - Client recovery `error` state shows the underlying client fetch error block instead of a generic "Server unavailable".
  - Refactor `ProfilePage` to reduce cognitive complexity: extract `extractSsrErrorDetails` / `safeStringify` / `parsePostId` / `parsePostSource` and split rendering into `NotFoundView` and `SsrRecoveryView`.
  - Move SSR debug inline styles into `page.module.scss` (CSS Module, scoped, cacheable).

## Scope

### In scope

- `src/app/profile/[id]/page.tsx`
- `src/app/profile/[id]/page.module.scss`
- `src/entities/profile/ui/Profile/ProfileClientRecovery.tsx`

### Out of scope

- Root-cause fix for SSR fetch failure on `/profile/[id]` (will be addressed in a follow-up PR once diagnostic data is captured in production).
- API contract / backend changes.
- Infrastructure / Cloudflare / k8s networking changes.
- Other SSR routes (only `/profile/[id]` is instrumented).

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

If architectural change is checked:

- add label `policy-change`
- fill `Contract change` section
- update `.ai/policy.md` version metadata

## Contract change

- What changed: N/A
- Why: N/A
- Impact/Migration: N/A
- Policy version updated: N/A

## Mandatory checklist

- [ ] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
  - `pnpm typecheck` — pass
  - `pnpm run ci:check` — pending in CI
  - `pnpm smoke:ssr` (against the deployed environment after merge) — to be run

### Manual

- Scenario 1: Open `https://ictroot.uk/profile/{existingId}` after deploy. Either the profile renders normally (SSR ok), or the page shows a yellow `[SSR debug]` block with `status / kind / url / message / bodyPreview` above the rendered profile/recovery — confirming real SSR error details are surfaced.
- Scenario 2: When client recovery also fails, the "Server unavailable" view shows a red `[Client debug]` block with the client-side fetch error details instead of a generic message.

## Risks and Rollback

- Risks:
  - Diagnostic blocks are visible to end users on the profile page when SSR/client fetch fails. They leak technical details (URL, status, response preview) — acceptable temporarily for diagnostics, must be removed after root cause is identified.
  - No behavior change for the happy path; if SSR succeeds, nothing visual changes.
- Rollback plan:
  - Revert this PR (no schema/contract changes, fully reversible).
  - Cleanup will be a follow-up PR removing the `data-ssr-debug` blocks and `page.module.scss` once the underlying issue is fixed.