### PR TITLE
Hotfix/profile ssr diag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@
 # Tunnel/proxy mode: set USE_API_PROXY=true and NEXT_PUBLIC_API_URL=/api/proxy
 NEXT_PUBLIC_API_URL=
 
+# Server-only: absolute API base for SSR/Node fetches in production (in-cluster or internal URL).
+# Use when the pod cannot reach the public browser URL (e.g. DNS / egress). Not exposed to the client.
+# Example: http://api-service.ns.svc.cluster.local:8080/api
+INTERNAL_API_BASE_URL=
+
 # Proxy target used by next.config.ts rewrites when NEXT_PUBLIC_API_URL starts with "/"
 # Example: https://ictroot.uk/api
 API_PROXY_TARGET=

--- a/src/app/profile/[id]/page.module.scss
+++ b/src/app/profile/[id]/page.module.scss
@@ -1,0 +1,14 @@
+.debugBlock {
+  white-space: pre-wrap;
+}
+
+.ssrDebugBlock {
+  background: #fff3cd;
+  border: 1px solid #ffeeba;
+  color: #856404;
+  padding: 8px 12px;
+  margin: 8px;
+  white-space: pre-wrap;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -128,7 +128,7 @@ const renderProfileError = (error: unknown, userId: number) => {
   return <ServerUnavailableView details={details} />
 }
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 60
 
 export default async function ProfilePage({ params, searchParams }: Readonly<Props>) {
   const [{ id }, query] = await Promise.all([params, searchParams])

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -7,6 +7,8 @@ import { Profile } from '@/entities/profile/ui'
 import { logger } from '@/shared/lib/logger'
 import { getSsrFetchErrorStatus } from '@/shared/lib/ssr/safeSsrFetch'
 
+import s from './page.module.scss'
+
 type Props = {
   params: Promise<{ id: string }>
   searchParams: Promise<{
@@ -15,17 +17,32 @@ type Props = {
   }>
 }
 
-const getSingleSearchParam = (value?: string | string[]) => {
-  if (Array.isArray(value)) {
-    return value[0]
-  }
-
-  return value
+type SsrErrorDetails = {
+  bodyPreview: string
+  kind: string
+  message: string
+  status: null | number
+  url: string
 }
 
-const isPostSource = (value: string): value is PostOpenSource => {
-  return value === 'home' || value === 'profile' || value === 'direct'
+const PAGE_SIZE = 8
+
+const POST_SOURCES: ReadonlySet<PostOpenSource> = new Set(['home', 'profile', 'direct'])
+
+const getSingleSearchParam = (value?: string | string[]) =>
+  Array.isArray(value) ? value[0] : value
+
+const isPostSource = (value: string): value is PostOpenSource =>
+  POST_SOURCES.has(value as PostOpenSource)
+
+const parsePostId = (raw?: string) => {
+  const parsed = raw ? Number(raw) : Number.NaN
+
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
 }
+
+const parsePostSource = (raw?: string): PostOpenSource =>
+  raw && isPostSource(raw) ? raw : 'direct'
 
 const getEmptyPosts = (pageSize: number): PaginatedPosts => ({
   items: [],
@@ -33,63 +50,112 @@ const getEmptyPosts = (pageSize: number): PaginatedPosts => ({
   pageSize,
 })
 
-export const dynamic = 'force-dynamic'
-
-export default async function ProfilePage({ params, searchParams }: Props) {
-  const { id } = await params
-  const query = await searchParams
-  const userId = Number(id)
-  const pageSize = 8
-
-  if (!Number.isInteger(userId) || userId <= 0) {
-    return (
-      <div>
-        <h1>Profile not found</h1>
-      </div>
-    )
+const readErrorField = (error: unknown, field: string): unknown => {
+  if (typeof error === 'object' && error !== null && field in error) {
+    return (error as Record<string, unknown>)[field]
   }
 
-  const postIdRaw = getSingleSearchParam(query.postId)
-  const parsedPostId = postIdRaw ? Number(postIdRaw) : NaN
-  const postId = Number.isInteger(parsedPostId) && parsedPostId > 0 ? parsedPostId : null
-  const sourceRaw = getSingleSearchParam(query.from)
-  const source = sourceRaw && isPostSource(sourceRaw) ? sourceRaw : 'direct'
+  return undefined
+}
+
+const safeStringify = (value: unknown, fallback = ''): string => {
+  if (value === undefined || value === null) {
+    return fallback
+  }
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value)
+  }
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return fallback
+  }
+}
+
+const extractSsrErrorDetails = (error: unknown): SsrErrorDetails => ({
+  status: getSsrFetchErrorStatus(error),
+  kind: safeStringify(readErrorField(error, 'kind'), 'unknown'),
+  url: safeStringify(readErrorField(error, 'url')),
+  bodyPreview: safeStringify(readErrorField(error, 'bodyPreview')),
+  message: error instanceof Error ? error.message : 'Unknown error',
+})
+
+const formatDebugLine = (details: SsrErrorDetails) =>
+  `status: ${details.status ?? 'n/a'} | kind: ${details.kind}\nurl: ${details.url}\nmessage: ${details.message}${
+    details.bodyPreview ? `\nbodyPreview: ${details.bodyPreview}` : ''
+  }`
+
+const NotFoundView = ({ details }: { details?: SsrErrorDetails }) => (
+  <div>
+    <h1>Profile not found</h1>
+    {details ? (
+      <pre className={s.debugBlock} data-ssr-debug={'profile-not-found'}>
+        {formatDebugLine(details)}
+      </pre>
+    ) : null}
+  </div>
+)
+
+const ServerUnavailableView = ({ details }: { details: SsrErrorDetails }) => (
+  <div>
+    <h1>Server unavailable</h1>
+    <p>Please try again later.</p>
+    <pre className={s.ssrDebugBlock} data-ssr-debug={'ssr-catch'}>
+      {`[SSR debug] ${formatDebugLine(details)}`}
+    </pre>
+  </div>
+)
+
+const renderProfileError = (error: unknown, userId: number) => {
+  const details = extractSsrErrorDetails(error)
+
+  logger.error('[ProfilePage] fetchProfileData failed', {
+    userId,
+    status: details.status,
+    kind: details.kind,
+    url: details.url,
+    errorMessage: details.message,
+    bodyPreview: details.bodyPreview,
+  })
+
+  if (details.status === 404) {
+    return <NotFoundView details={details} />
+  }
+
+  return <ServerUnavailableView details={details} />
+}
+
+export const dynamic = 'force-dynamic'
+
+export default async function ProfilePage({ params, searchParams }: Readonly<Props>) {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const userId = Number(id)
+
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return <NotFoundView />
+  }
+
+  const initialPostId = parsePostId(getSingleSearchParam(query.postId))
+  const initialPostSource = parsePostSource(getSingleSearchParam(query.from))
 
   let profileDataServer
 
   try {
     profileDataServer = await fetchProfileData(userId)
   } catch (error) {
-    const status = getSsrFetchErrorStatus(error)
-
-    logger.error('[ProfilePage] fetchProfileData failed', {
-      status,
-      userId,
-      errorMessage: error instanceof Error ? error.message : 'Unknown error',
-    })
-
-    if (status === 404) {
-      return (
-        <div>
-          <h1>Profile not found</h1>
-        </div>
-      )
-    }
-
-    return (
-      <div>
-        <h1>Server unavailable</h1>
-        <p>Please try again later.</p>
-      </div>
-    )
+    return renderProfileError(error, userId)
   }
 
   const [postsResult, initialPostResult] = await Promise.allSettled([
-    fetchUserPosts(userId, pageSize, profileDataServer.userName),
-    postId ? fetchPostByIdForSSR(postId) : Promise.resolve(null),
+    fetchUserPosts(userId, PAGE_SIZE, profileDataServer.userName),
+    initialPostId ? fetchPostByIdForSSR(initialPostId) : Promise.resolve(null),
   ])
 
-  const postsData = postsResult.status === 'fulfilled' ? postsResult.value : getEmptyPosts(pageSize)
+  const postsData =
+    postsResult.status === 'fulfilled' ? postsResult.value : getEmptyPosts(PAGE_SIZE)
   const initialPostDataServer =
     initialPostResult.status === 'fulfilled' ? initialPostResult.value : null
 
@@ -97,9 +163,9 @@ export default async function ProfilePage({ params, searchParams }: Props) {
     <Profile
       profileDataServer={profileDataServer}
       postsDataServer={postsData}
-      initialPostIdServer={postId}
+      initialPostIdServer={initialPostId}
       initialPostDataServer={initialPostDataServer}
-      initialPostSourceServer={source}
+      initialPostSourceServer={initialPostSource}
     />
   )
 }

--- a/src/entities/profile/lib/profile-queries.ts
+++ b/src/entities/profile/lib/profile-queries.ts
@@ -5,7 +5,13 @@ import { safeSsrFetchJson, toSsrFetchException } from '@/shared/lib/ssr/safeSsrF
 
 import { PublicProfileData } from '../api'
 
-const REQUEST_OPTIONS = { cache: 'no-store' as const }
+const PROFILE_SSR_REVALIDATE_SECONDS = 60
+
+const REQUEST_OPTIONS = {
+  next: {
+    revalidate: PROFILE_SSR_REVALIDATE_SECONDS,
+  },
+} as const
 
 async function fetchProfileData(userId: number): Promise<PublicProfileData> {
   const url = buildApiUrl(API_ROUTES.PUBLIC_USER.PROFILE(userId))
@@ -14,6 +20,7 @@ async function fetchProfileData(userId: number): Promise<PublicProfileData> {
   if (!result.ok) {
     logger.error('[fetchProfileData] request failed', {
       bodyPreview: result.error.bodyPreview,
+      causeCode: result.error.causeCode,
       kind: result.error.kind,
       message: result.error.message,
       status: result.error.status,

--- a/src/shared/api/get-api-base-url.ts
+++ b/src/shared/api/get-api-base-url.ts
@@ -11,6 +11,15 @@ const ensureLeadingSlash = (value: string) => (value.startsWith('/') ? value : `
 const stripProxySuffix = (value: string) => value.replace(/\/proxy$/, '')
 
 const getProductionApiBase = () => {
+  // Server-only: k8s / private network often cannot resolve or reach the public
+  // browser URL — use an internal service base (no NEXT_PUBLIC_ prefix on purpose).
+  const isServer = globalThis.window === undefined
+  const internalBase = trimTrailingSlash(process.env.INTERNAL_API_BASE_URL?.trim() || '')
+
+  if (isServer && internalBase && isAbsoluteUrl(internalBase)) {
+    return stripProxySuffix(internalBase)
+  }
+
   const configuredBase = trimTrailingSlash(process.env.NEXT_PUBLIC_API_URL?.trim() || '')
 
   if (configuredBase && isAbsoluteUrl(configuredBase)) {
@@ -39,7 +48,7 @@ export const getApiBaseUrl = () => {
     return normalizedBase
   }
 
-  if (typeof window !== 'undefined') {
+  if (globalThis.window !== undefined) {
     return ensureLeadingSlash(normalizedBase)
   }
 

--- a/src/shared/lib/ssr/safeSsrFetch.test.ts
+++ b/src/shared/lib/ssr/safeSsrFetch.test.ts
@@ -67,4 +67,22 @@ describe('safeSsrFetchJson', () => {
       expect(result.error.message).toContain('ENOTFOUND')
     }
   })
+
+  it('attaches causeCode for network errors with Error.cause chain', async () => {
+    const inner = new Error('dns') as Error & { code: string }
+
+    inner.code = 'ENOTFOUND'
+    const fetchMock = vi.fn().mockRejectedValue(new Error('fetch failed', { cause: inner }))
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch)
+
+    const result = await safeSsrFetchJson('https://example.com/network-cause')
+
+    expect(result.ok).toBe(false)
+
+    if (!result.ok) {
+      expect(result.error.kind).toBe('network')
+      expect(result.error.causeCode).toBe('ENOTFOUND')
+    }
+  })
 })

--- a/src/shared/lib/ssr/safeSsrFetch.ts
+++ b/src/shared/lib/ssr/safeSsrFetch.ts
@@ -2,6 +2,7 @@ export type SsrFetchErrorKind = 'http' | 'network' | 'parse'
 
 export type SsrFetchError = {
   bodyPreview?: string
+  causeCode?: string
   kind: SsrFetchErrorKind
   message: string
   status?: number
@@ -9,6 +10,20 @@ export type SsrFetchError = {
 }
 
 export type SsrFetchException = Error & SsrFetchError
+
+const getCauseCode = (error: unknown): string | undefined => {
+  if (error instanceof Error) {
+    const { cause } = error as Error & { cause?: unknown }
+
+    if (cause && typeof cause === 'object' && 'code' in cause) {
+      const code = (cause as { code?: unknown }).code
+
+      return typeof code === 'string' ? code : undefined
+    }
+  }
+
+  return undefined
+}
 
 type SsrFetchInit = globalThis.RequestInit & {
   next?: {
@@ -41,6 +56,7 @@ export const toSsrFetchException = (error: SsrFetchError): SsrFetchException => 
   exception.url = error.url
   exception.status = error.status
   exception.bodyPreview = error.bodyPreview
+  exception.causeCode = error.causeCode
 
   return exception
 }
@@ -72,10 +88,15 @@ export const safeSsrFetchJson = async <TData>(
   try {
     response = await fetch(url, init)
   } catch (error) {
+    const causeCode = getCauseCode(error)
+
     return {
       error: {
+        causeCode,
         kind: 'network',
-        message: toUnknownErrorMessage(error),
+        message: causeCode
+          ? `${toUnknownErrorMessage(error)} [${causeCode}]`
+          : toUnknownErrorMessage(error),
         url,
       },
       ok: false,


### PR DESCRIPTION
## Summary

- Jira: —
- What changed: улучшена диагностика SSR-ошибок на странице профиля и добавлена
  поддержка внутреннего API base URL для SSR в k8s-окружении

## Scope

### In scope

- `safeSsrFetch`: новое поле `causeCode` (ENOTFOUND / ECONNREFUSED / ETIMEDOUT)
  в типах `SsrFetchError` / `SsrFetchException`; извлекается из `Error.cause.code`
- `profile-queries`: `causeCode` логируется при провале `fetchProfileData`
- `profile/[id]/page`: `force-dynamic` → `revalidate = 60` (ISR, как главная)
- `profile-queries`: `cache: 'no-store'` → `next: { revalidate: 60 }`
- `get-api-base-url`: сервер-only `INTERNAL_API_BASE_URL` — SSR использует
  внутренний k8s-адрес, клиент — `NEXT_PUBLIC_API_URL`; решает hairpin NAT
- `.env.example`: задокументирована переменная `INTERNAL_API_BASE_URL`

### Out of scope

- Правки инфраструктуры / k8s-манифестов
- Изменения в компоненте `<Profile />`
- Авторизационные запросы (`/me`)

## Architecture impact

- [x] No architectural boundaries changed

## Contract change

_N/A_

## Mandatory checklist

- [ ] `pnpm run ci:check` is green
- [ ] No new `any` in production code
- [ ] Manual verification scenarios are listed
- [ ] Risks and rollback strategy are documented

## Verification evidence

### Automated

### Manual

- Scenario 1: открыть `/profile/71` локально → страница рендерится, данные
  профиля отображаются, нет регрессий
- Scenario 2: в prod-логах (kubectl logs) при сетевой ошибке SSR теперь видно
  `causeCode: 'ENOTFOUND'` вместо просто `fetch failed`
- Scenario 3: при установке `INTERNAL_API_BASE_URL=<internal>` в env SSR
  использует внутренний адрес (проверить `[fetchProfileData]` лог — url
  должен быть внутренним)

## Risks and Rollback

- Risks: минимальные — изменения только в диагностике и кешировании;
  `revalidate=60` вместо `no-store` означает что профиль может отдаваться
  из кеша до 60 с (приемлемо по ТЗ)
- Rollback plan: откатить коммит (`git revert`); `INTERNAL_API_BASE_URL`
  не обязателен — без него поведение идентично предыдущему (fallback на
  `NEXT_PUBLIC_API_URL`)