### PR TITLE
Scrum 283 fix user search follow sync

### DIFF
--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -5,7 +5,10 @@ import { fetchPostByIdForSSR, fetchUserPosts } from '@/entities/posts/lib'
 import { fetchProfileData } from '@/entities/profile/lib'
 import { logger } from '@/shared/lib/logger'
 import { getSsrFetchErrorStatus } from '@/shared/lib/ssr/safeSsrFetch'
-import { ProfileWithPostLikes } from '@/widgets/ProfileWithPostLikes'
+import {
+  ProfileWithPostLikes,
+  ProfileWithPostLikesByUserName,
+} from '@/widgets/ProfileWithPostLikes'
 
 type Props = {
   params: Promise<{ id: string }>
@@ -33,6 +36,8 @@ const parsePostId = (raw?: string) => {
 
 const parsePostSource = (raw?: string): PostOpenSource =>
   raw && isPostSource(raw) ? raw : 'direct'
+
+const isValidProfileUserName = (value: string) => /^[A-Za-z0-9._-]{1,30}$/.test(value)
 
 const getEmptyPosts = (pageSize: number): PaginatedPosts => ({
   items: [],
@@ -74,6 +79,10 @@ export default async function ProfilePage({ params, searchParams }: Readonly<Pro
   const userId = Number(id)
 
   if (!Number.isInteger(userId) || userId <= 0) {
+    if (isValidProfileUserName(id)) {
+      return <ProfileWithPostLikesByUserName userName={id} />
+    }
+
     return <NotFoundView />
   }
 
@@ -102,6 +111,7 @@ export default async function ProfilePage({ params, searchParams }: Readonly<Pro
     <ProfileWithPostLikes
       profileDataServer={profileDataServer}
       postsDataServer={postsData}
+      resolvedUserId={userId}
       initialPostIdServer={initialPostId}
       initialPostDataServer={initialPostDataServer}
       initialPostSourceServer={initialPostSource}

--- a/src/entities/posts/hooks/usePostModal.ts
+++ b/src/entities/posts/hooks/usePostModal.ts
@@ -174,14 +174,24 @@ export const usePostModal = (
   const {
     isFollowing,
     isFollowPending,
-    handleFollow: followOrUnfollow,
-  } = useFollowUserState(ownerUserName || '', postData?.ownerId ?? 0)
+    handleFollow: followPostOwner,
+    handleUnfollow: unfollowPostOwner,
+  } = useFollowUserState(ownerUserName || '', postData?.ownerId ?? 0, user?.userId, {
+    enabled: Boolean(isAuthenticatedUi && !isOwnProfile),
+  })
 
   const handleFollow = async () => {
     if (isFollowPending) {
       return
     }
-    await followOrUnfollow()
+
+    if (isFollowing) {
+      await unfollowPostOwner()
+
+      return
+    }
+
+    await followPostOwner()
   }
 
   const handleCopyLink = async () => {

--- a/src/entities/profile/hooks/useProfile.ts
+++ b/src/entities/profile/hooks/useProfile.ts
@@ -3,19 +3,18 @@
 import { type PaginatedPosts, useGetPostsByUserInfiniteQuery } from '@/entities/posts/api'
 import { type PublicProfileData, useGetPublicProfileQuery } from '@/entities/profile/api'
 import { useInitializeProfile } from '@/entities/profile/hooks'
-import { useGetUserByUserNameQuery } from '@/entities/users/api'
 import { useFollowUserState } from '@/entities/users/hooks/useFollowUserState'
 import { useMeQuery } from '@/features/auth'
 import { useAuthSessionHintContext } from '@/shared/auth'
 import { APP_ROUTES } from '@/shared/constant'
-import { useParams, useRouter } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 
 export const useProfile = (
   profileDataServer: PublicProfileData,
-  postsDataServer: PaginatedPosts
+  postsDataServer: PaginatedPosts,
+  resolvedUserId: number
 ) => {
-  const { id } = useParams<{ id: string }>()
-  const userId = Number(id)
+  const userId = resolvedUserId
   const router = useRouter()
   const profileQueryArgs = { profileId: userId }
   const postsQueryArgs = { userId }
@@ -54,30 +53,24 @@ export const useProfile = (
   // The public profile endpoint is unauthenticated, so its `isFollowing` is always false.
   // Fetch the real per-viewer follow status from the authenticated by-userName endpoint.
   const isViewerOwnProfile = Boolean(user?.userId && profile.id === user.userId)
-  const { data: followState } = useGetUserByUserNameQuery(profile.userName, {
-    skip: !user || isViewerOwnProfile || !profile.userName,
-  })
 
   const {
     isFollowing,
     followersCount,
     followingCount,
+    publicationsCount,
     isFollowPending,
     handleFollow,
     handleUnfollow,
-  } = useFollowUserState(profile.userName, profile.id)
+  } = useFollowUserState(profile.userName, profile.id, user?.userId, {
+    enabled: Boolean(user && !isViewerOwnProfile),
+  })
 
   // Use the live authenticated counts; fall back to the SSR public-profile metadata
   const userMetadata = {
-    followers:
-      followersCount !== 0
-        ? followersCount
-        : (followState?.followersCount ?? profile.userMetadata.followers),
-    following:
-      followingCount !== 0
-        ? followingCount
-        : (followState?.followingCount ?? profile.userMetadata.following),
-    publications: followState?.publicationsCount ?? profile.userMetadata.publications,
+    followers: followersCount ?? profile.userMetadata.followers,
+    following: followingCount ?? profile.userMetadata.following,
+    publications: publicationsCount ?? profile.userMetadata.publications,
   }
 
   const posts = postsData?.pages?.flatMap(page => page.items || []) || postsDataServer?.items || []

--- a/src/entities/profile/ui/Profile/Profile.tsx
+++ b/src/entities/profile/ui/Profile/Profile.tsx
@@ -24,6 +24,7 @@ export type ProfileProps = {
   initialPostSourceServer?: PostOpenSource
   postModalAuthState?: PostModalAuthState
   renderPostLikeAction?: RenderPostLikeAction
+  resolvedUserId: number
 }
 
 export function Profile({
@@ -34,6 +35,7 @@ export function Profile({
   initialPostSourceServer = 'direct',
   postModalAuthState,
   renderPostLikeAction,
+  resolvedUserId,
 }: Readonly<ProfileProps>) {
   const {
     posts,
@@ -47,7 +49,7 @@ export function Profile({
     authActionSkeletonVariant,
     profileInfoActions,
     loadMorePostsHandler,
-  } = useProfile(profileDataServer, postsDataServer)
+  } = useProfile(profileDataServer, postsDataServer, resolvedUserId)
 
   if (isLoading) {
     return <Loading />

--- a/src/entities/users/api/follow-cache.ts
+++ b/src/entities/users/api/follow-cache.ts
@@ -1,0 +1,38 @@
+import type { UserByUserNameResponse } from './api.types'
+import type { PublicProfileData } from '@/entities/profile/api'
+
+export type FollowCachePatch = {
+  followersDelta: number
+  followingDelta: number
+  isFollowing: boolean
+}
+
+export type CachePatchResult = {
+  undo: () => void
+}
+
+export const isValidUserId = (userId: number | undefined): userId is number =>
+  typeof userId === 'number' && Number.isInteger(userId) && userId > 0
+
+export const patchUserByUserNameFollowState = (
+  draft: UserByUserNameResponse,
+  { followersDelta, isFollowing }: FollowCachePatch
+) => {
+  draft.isFollowing = isFollowing
+  draft.followersCount = Math.max(0, draft.followersCount + followersDelta)
+}
+
+export const patchPublicProfileFollowers = (
+  draft: PublicProfileData,
+  { followersDelta, isFollowing }: FollowCachePatch
+) => {
+  draft.isFollowing = isFollowing
+  draft.userMetadata.followers = Math.max(0, draft.userMetadata.followers + followersDelta)
+}
+
+export const patchPublicProfileFollowing = (
+  draft: PublicProfileData,
+  { followingDelta }: FollowCachePatch
+) => {
+  draft.userMetadata.following = Math.max(0, draft.userMetadata.following + followingDelta)
+}

--- a/src/entities/users/api/publicUsers.api.ts
+++ b/src/entities/users/api/publicUsers.api.ts
@@ -1,11 +1,8 @@
-import type { PublicProfileData } from '@/entities/profile/api'
-
 import { GetPublicUsers } from '@/entities/users/model'
 import { API_ROUTES } from '@/shared/api/api-routes'
 import { baseApi } from '@/shared/api/base-api'
 
 import {
-  FollowUserRequest,
   GetPublicPostsRequest,
   GetPublicPostsResponse,
   SearchUsersRequest,
@@ -13,181 +10,14 @@ import {
   UserByUserNameResponse,
 } from './api.types'
 
-type BaseQueryState = {
-  baseApi?: {
-    queries?: Record<string, { data?: unknown }>
-  }
-}
-
-const updateBaseQueryData = baseApi.util.updateQueryData as any
-
 export const publicUsersApi = baseApi.injectEndpoints({
   endpoints: builder => ({
-    followProfileUser: builder.mutation<void, FollowUserRequest>({
-      query: body => ({
-        url: API_ROUTES.USERS_FOLLOW.FOLLOWING,
-        method: 'POST',
-        body,
-      }),
-      async onQueryStarted({ selectedUserId }, { dispatch, queryFulfilled, getState }) {
-        const state = getState() as BaseQueryState
-        const meUser = state.baseApi?.queries?.me?.data as { userId?: number } | undefined
-        const currentUserId = meUser?.userId
-
-        const targetProfileQuery = Object.entries(state.baseApi?.queries || {}).find(
-          ([key]) => key.includes('getPublicProfile') && key.includes(String(selectedUserId))
-        )
-        const targetProfileData = targetProfileQuery?.[1]?.data as PublicProfileData | undefined
-        const targetUserName = targetProfileData?.userName
-
-        const patchTarget = (isFollowing: boolean, followersDelta: number) => {
-          dispatch(
-            updateBaseQueryData(
-              'getPublicProfile',
-              { profileId: selectedUserId },
-              (draft: PublicProfileData | undefined) => {
-                if (!draft) {
-                  return
-                }
-
-                draft.isFollowing = isFollowing
-                draft.userMetadata.followers += followersDelta
-              }
-            )
-          )
-          if (targetUserName) {
-            dispatch(
-              updateBaseQueryData(
-                'getUserByUserName',
-                targetUserName,
-                (draft: UserByUserNameResponse | undefined) => {
-                  if (!draft) {
-                    return
-                  }
-
-                  draft.isFollowing = isFollowing
-                  draft.followersCount += followersDelta
-                }
-              )
-            )
-          }
-        }
-
-        const patchMe = (followingDelta: number) => {
-          if (currentUserId) {
-            dispatch(
-              updateBaseQueryData(
-                'getPublicProfile',
-                { profileId: currentUserId },
-                (draft: PublicProfileData | undefined) => {
-                  if (!draft) {
-                    return
-                  }
-
-                  draft.userMetadata.following += followingDelta
-                }
-              )
-            )
-          }
-        }
-
-        patchTarget(true, 1)
-        patchMe(1)
-
-        try {
-          await queryFulfilled
-        } catch {
-          patchTarget(false, -1)
-          patchMe(-1)
-        }
-      },
-      invalidatesTags: ['Profile'],
-    }),
-    unfollowProfileUser: builder.mutation<void, number>({
-      query: userId => ({
-        url: API_ROUTES.USERS_FOLLOW.DELETE_FOLLOWER(userId),
-        method: 'DELETE',
-      }),
-      async onQueryStarted(selectedUserId, { dispatch, queryFulfilled, getState }) {
-        const state = getState() as BaseQueryState
-        const meUser = state.baseApi?.queries?.me?.data as { userId?: number } | undefined
-        const currentUserId = meUser?.userId
-
-        const targetProfileQuery = Object.entries(state.baseApi?.queries || {}).find(
-          ([key]) => key.includes('getPublicProfile') && key.includes(String(selectedUserId))
-        )
-        const targetProfileData = targetProfileQuery?.[1]?.data as PublicProfileData | undefined
-        const targetUserName = targetProfileData?.userName
-
-        const patchTarget = (isFollowing: boolean, followersDelta: number) => {
-          dispatch(
-            updateBaseQueryData(
-              'getPublicProfile',
-              { profileId: selectedUserId },
-              (draft: PublicProfileData | undefined) => {
-                if (!draft) {
-                  return
-                }
-
-                draft.isFollowing = isFollowing
-                draft.userMetadata.followers += followersDelta
-              }
-            )
-          )
-          if (targetUserName) {
-            dispatch(
-              updateBaseQueryData(
-                'getUserByUserName',
-                targetUserName,
-                (draft: UserByUserNameResponse | undefined) => {
-                  if (!draft) {
-                    return
-                  }
-
-                  draft.isFollowing = isFollowing
-                  draft.followersCount += followersDelta
-                }
-              )
-            )
-          }
-        }
-
-        const patchMe = (followingDelta: number) => {
-          if (currentUserId) {
-            dispatch(
-              updateBaseQueryData(
-                'getPublicProfile',
-                { profileId: currentUserId },
-                (draft: PublicProfileData | undefined) => {
-                  if (!draft) {
-                    return
-                  }
-
-                  draft.userMetadata.following += followingDelta
-                }
-              )
-            )
-          }
-        }
-
-        patchTarget(false, -1)
-        patchMe(-1)
-
-        try {
-          await queryFulfilled
-        } catch {
-          patchTarget(true, 1)
-          patchMe(1)
-        }
-      },
-      invalidatesTags: ['Profile'],
-    }),
     // Authenticated lookup that returns the per-viewer follow status (isFollowing).
     getUserByUserName: builder.query<UserByUserNameResponse, string>({
       query: userName => ({
         url: API_ROUTES.USERS_FOLLOW.BY_USERNAME(userName),
       }),
-      providesTags: ['Profile'],
+      providesTags: (result, error, userName) => [{ type: 'Profile', id: `USERNAME-${userName}` }],
     }),
     getPublicUsersCounter: builder.query<GetPublicUsers, void>({
       query: () => ({
@@ -213,7 +43,6 @@ export const {
   useGetPublicUsersCounterQuery,
   useGetPublicPostsQuery,
   useSearchUsersQuery,
-  useFollowProfileUserMutation,
-  useUnfollowProfileUserMutation,
   useGetUserByUserNameQuery,
 } = publicUsersApi
+

--- a/src/entities/users/api/usersFollow.api.test.ts
+++ b/src/entities/users/api/usersFollow.api.test.ts
@@ -1,23 +1,66 @@
 /* @vitest-environment node */
 
 import { profileApi } from '@/entities/profile/api/profileApi'
-import { API_ROUTES } from '@/shared/api'
+import { baseApi } from '@/shared/api/base-api'
 import { configureStore } from '@reduxjs/toolkit'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { publicUsersApi } from './publicUsers.api'
 import { usersFollowApi } from './usersFollow.api'
+
+const targetProfile = {
+  id: 7,
+  userName: 'john',
+  aboutMe: null,
+  avatars: [],
+  isFollowing: false,
+  isFollowedBy: false,
+  userMetadata: {
+    followers: 2,
+    following: 3,
+    publications: 1,
+  },
+}
+
+const currentProfile = {
+  id: 8,
+  userName: 'me',
+  aboutMe: null,
+  avatars: [],
+  isFollowing: false,
+  isFollowedBy: false,
+  userMetadata: {
+    followers: 1,
+    following: 5,
+    publications: 2,
+  },
+}
+
+const targetByUserName = {
+  id: 7,
+  userName: 'john',
+  firstName: null,
+  lastName: null,
+  aboutMe: null,
+  avatars: [],
+  isFollowing: false,
+  isFollowedBy: false,
+  followersCount: 2,
+  followingCount: 3,
+  publicationsCount: 1,
+}
 
 const createTestStore = () =>
   configureStore({
     reducer: {
-      [usersFollowApi.reducerPath]: usersFollowApi.reducer,
+      [baseApi.reducerPath]: baseApi.reducer,
     },
-    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(usersFollowApi.middleware),
+    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(baseApi.middleware),
   })
 
-const asJsonResponse = (body: unknown) =>
+const asJsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: { 'Content-Type': 'application/json' },
   })
 
@@ -31,36 +74,134 @@ const asRequest = (call: unknown[]) => {
   return new Request(String(input), init as ConstructorParameters<typeof Request>[1])
 }
 
+const createDeferred = <T>() => {
+  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, reject, resolve }
+}
+
+const primeFollowCaches = async (store: ReturnType<typeof createTestStore>) => {
+  await store.dispatch(profileApi.endpoints.getPublicProfile.initiate({ profileId: 7 })).unwrap()
+  await store.dispatch(profileApi.endpoints.getPublicProfile.initiate({ profileId: 8 })).unwrap()
+  await store.dispatch(publicUsersApi.endpoints.getUserByUserName.initiate('john')).unwrap()
+}
+
+const getTargetProfile = (store: ReturnType<typeof createTestStore>) =>
+  profileApi.endpoints.getPublicProfile.select({ profileId: 7 })(store.getState()).data
+
+const getCurrentProfile = (store: ReturnType<typeof createTestStore>) =>
+  profileApi.endpoints.getPublicProfile.select({ profileId: 8 })(store.getState()).data
+
+const getTargetByUserName = (store: ReturnType<typeof createTestStore>) =>
+  publicUsersApi.endpoints.getUserByUserName.select('john')(store.getState()).data
+
+const getFetchPathNames = (fetchMock: ReturnType<typeof vi.fn>) =>
+  fetchMock.mock.calls.map(call => new URL(asRequest(call).url).pathname)
+
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe('usersFollowApi profile invalidation', () => {
-  it('refetches current and selected user profiles after follow and unfollow', async () => {
-    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(asJsonResponse({})))
+describe('usersFollowApi cache contract', () => {
+  it('optimistically patches target and current-user follow counters', async () => {
+    const followRequest = createDeferred<Response>()
+    const fetchMock = vi.fn().mockImplementation((...call: unknown[]) => {
+      const request = asRequest(call)
+      const { pathname } = new URL(request.url)
+
+      if (request.method === 'POST') {
+        return followRequest.promise
+      }
+
+      if (pathname.endsWith('/v1/public-user/profile/7')) {
+        return Promise.resolve(asJsonResponse(targetProfile))
+      }
+
+      if (pathname.endsWith('/v1/public-user/profile/8')) {
+        return Promise.resolve(asJsonResponse(currentProfile))
+      }
+
+      if (pathname.endsWith('/v1/users/john')) {
+        return Promise.resolve(asJsonResponse(targetByUserName))
+      }
+
+      return Promise.resolve(asJsonResponse({}))
+    })
     const store = createTestStore()
 
     vi.stubGlobal('fetch', fetchMock as typeof fetch)
+    await primeFollowCaches(store)
 
-    await store.dispatch(profileApi.endpoints.getPublicProfile.initiate({ profileId: 7 }))
-    await store.dispatch(profileApi.endpoints.getPublicProfile.initiate({ profileId: 8 }))
-    await store.dispatch(
-      usersFollowApi.endpoints.followUser.initiate({ currentUserId: 8, selectedUserId: 7 })
+    const mutation = store.dispatch(
+      usersFollowApi.endpoints.followUser.initiate({
+        currentUserId: 8,
+        selectedUserId: 7,
+        targetUserName: 'john',
+      })
     )
 
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5))
+    expect(getTargetProfile(store)?.isFollowing).toBe(true)
+    expect(getTargetProfile(store)?.userMetadata.followers).toBe(3)
+    expect(getCurrentProfile(store)?.userMetadata.following).toBe(6)
+    expect(getTargetByUserName(store)?.isFollowing).toBe(true)
+    expect(getTargetByUserName(store)?.followersCount).toBe(3)
+
+    followRequest.resolve(asJsonResponse({}))
+    await mutation
+
+    expect(getFetchPathNames(fetchMock)).toEqual([
+      '/api/v1/public-user/profile/7',
+      '/api/v1/public-user/profile/8',
+      '/api/v1/users/john',
+      '/api/v1/users/following',
+    ])
+  })
+
+  it('rolls back exactly the patched caches when follow fails', async () => {
+    const fetchMock = vi.fn().mockImplementation((...call: unknown[]) => {
+      const request = asRequest(call)
+      const { pathname } = new URL(request.url)
+
+      if (request.method === 'POST') {
+        return Promise.resolve(asJsonResponse({ message: 'failed' }, 500))
+      }
+
+      if (pathname.endsWith('/v1/public-user/profile/7')) {
+        return Promise.resolve(asJsonResponse(targetProfile))
+      }
+
+      if (pathname.endsWith('/v1/public-user/profile/8')) {
+        return Promise.resolve(asJsonResponse(currentProfile))
+      }
+
+      if (pathname.endsWith('/v1/users/john')) {
+        return Promise.resolve(asJsonResponse(targetByUserName))
+      }
+
+      return Promise.resolve(asJsonResponse({}))
+    })
+    const store = createTestStore()
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch)
+    await primeFollowCaches(store)
 
     await store.dispatch(
-      usersFollowApi.endpoints.unfollowUser.initiate({ currentUserId: 8, selectedUserId: 7 })
+      usersFollowApi.endpoints.followUser.initiate({
+        currentUserId: 8,
+        selectedUserId: 7,
+        targetUserName: 'john',
+      })
     )
 
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(8))
-
-    const requestedPaths = fetchMock.mock.calls.map(call => new URL(asRequest(call).url).pathname)
-    const publicProfileRequests = (profileId: number) =>
-      requestedPaths.filter(path => path.endsWith(API_ROUTES.PUBLIC_USER.PROFILE(profileId)))
-
-    expect(publicProfileRequests(7)).toHaveLength(3)
-    expect(publicProfileRequests(8)).toHaveLength(3)
+    expect(getTargetProfile(store)?.isFollowing).toBe(false)
+    expect(getTargetProfile(store)?.userMetadata.followers).toBe(2)
+    expect(getCurrentProfile(store)?.userMetadata.following).toBe(5)
+    expect(getTargetByUserName(store)?.isFollowing).toBe(false)
+    expect(getTargetByUserName(store)?.followersCount).toBe(2)
   })
 })

--- a/src/entities/users/api/usersFollow.api.ts
+++ b/src/entities/users/api/usersFollow.api.ts
@@ -1,39 +1,166 @@
+import { profileApi } from '@/entities/profile/api/profileApi'
+import { publicUsersApi } from '@/entities/users/api/publicUsers.api'
 import { API_ROUTES } from '@/shared/api/api-routes'
 import { baseApi } from '@/shared/api/base-api'
 import { UserSubscriptionInputDto } from '@/shared/types'
 
+import {
+  CachePatchResult,
+  isValidUserId,
+  patchPublicProfileFollowers,
+  patchPublicProfileFollowing,
+  patchUserByUserNameFollowState,
+} from './follow-cache'
+
 type FollowUserArgs = UserSubscriptionInputDto & {
-  currentUserId: number
+  currentUserId?: number
+  targetUserName?: string
 }
 
 type UnfollowUserArgs = {
-  currentUserId: number
+  currentUserId?: number
   selectedUserId: number
+  targetUserName?: string
 }
 
-const getAffectedProfileTags = (currentUserId: number, selectedUserId: number) => [
-  { type: 'Profile' as const, id: currentUserId },
+const getAffectedProfileTags = (
+  currentUserId: number | undefined,
+  selectedUserId: number,
+  targetUserName?: string
+) => [
+  ...(currentUserId ? [{ type: 'Profile' as const, id: currentUserId }] : []),
   { type: 'Profile' as const, id: selectedUserId },
+  ...(targetUserName ? [{ type: 'Profile' as const, id: `USERNAME-${targetUserName}` }] : []),
 ]
 
 export const usersFollowApi = baseApi.injectEndpoints({
   endpoints: builder => ({
     followUser: builder.mutation<void, FollowUserArgs>({
-      query: ({ currentUserId, ...body }) => ({
+      query: ({ currentUserId, targetUserName, ...body }) => ({
         url: API_ROUTES.USERS_FOLLOW.FOLLOWING,
         method: 'POST',
         body,
       }),
-      invalidatesTags: (result, error, { currentUserId, selectedUserId }) =>
-        getAffectedProfileTags(currentUserId, selectedUserId),
+      async onQueryStarted(
+        { currentUserId, selectedUserId, targetUserName },
+        { dispatch, queryFulfilled }
+      ) {
+        const patch = {
+          followersDelta: 1,
+          followingDelta: 1,
+          isFollowing: true,
+        }
+        const patches: CachePatchResult[] = []
+
+        if (targetUserName) {
+          patches.push(
+            dispatch(
+              publicUsersApi.util.updateQueryData('getUserByUserName', targetUserName, draft => {
+                patchUserByUserNameFollowState(draft, patch)
+              })
+            )
+          )
+        }
+
+        if (isValidUserId(selectedUserId)) {
+          patches.push(
+            dispatch(
+              profileApi.util.updateQueryData(
+                'getPublicProfile',
+                { profileId: selectedUserId },
+                draft => {
+                  patchPublicProfileFollowers(draft, patch)
+                }
+              )
+            )
+          )
+        }
+
+        if (isValidUserId(currentUserId)) {
+          patches.push(
+            dispatch(
+              profileApi.util.updateQueryData(
+                'getPublicProfile',
+                { profileId: currentUserId },
+                draft => {
+                  patchPublicProfileFollowing(draft, patch)
+                }
+              )
+            )
+          )
+        }
+
+        try {
+          await queryFulfilled
+        } catch {
+          patches.forEach(patch => patch.undo())
+        }
+      },
+      invalidatesTags: (result, error, { currentUserId, selectedUserId, targetUserName }) =>
+        error ? getAffectedProfileTags(currentUserId, selectedUserId, targetUserName) : [],
     }),
     unfollowUser: builder.mutation<void, UnfollowUserArgs>({
-      query: ({ selectedUserId }) => ({
+      query: ({ currentUserId, targetUserName, selectedUserId }) => ({
         url: API_ROUTES.USERS_FOLLOW.DELETE_FOLLOWER(selectedUserId),
         method: 'DELETE',
       }),
-      invalidatesTags: (result, error, { currentUserId, selectedUserId }) =>
-        getAffectedProfileTags(currentUserId, selectedUserId),
+      async onQueryStarted(
+        { currentUserId, selectedUserId, targetUserName },
+        { dispatch, queryFulfilled }
+      ) {
+        const patch = {
+          followersDelta: -1,
+          followingDelta: -1,
+          isFollowing: false,
+        }
+        const patches: CachePatchResult[] = []
+
+        if (targetUserName) {
+          patches.push(
+            dispatch(
+              publicUsersApi.util.updateQueryData('getUserByUserName', targetUserName, draft => {
+                patchUserByUserNameFollowState(draft, patch)
+              })
+            )
+          )
+        }
+
+        if (isValidUserId(selectedUserId)) {
+          patches.push(
+            dispatch(
+              profileApi.util.updateQueryData(
+                'getPublicProfile',
+                { profileId: selectedUserId },
+                draft => {
+                  patchPublicProfileFollowers(draft, patch)
+                }
+              )
+            )
+          )
+        }
+
+        if (isValidUserId(currentUserId)) {
+          patches.push(
+            dispatch(
+              profileApi.util.updateQueryData(
+                'getPublicProfile',
+                { profileId: currentUserId },
+                draft => {
+                  patchPublicProfileFollowing(draft, patch)
+                }
+              )
+            )
+          )
+        }
+
+        try {
+          await queryFulfilled
+        } catch {
+          patches.forEach(patch => patch.undo())
+        }
+      },
+      invalidatesTags: (result, error, { currentUserId, selectedUserId, targetUserName }) =>
+        error ? getAffectedProfileTags(currentUserId, selectedUserId, targetUserName) : [],
     }),
   }),
 })

--- a/src/entities/users/hooks/useFollowUserState.ts
+++ b/src/entities/users/hooks/useFollowUserState.ts
@@ -1,28 +1,48 @@
 'use client'
 
 import {
-  useFollowProfileUserMutation,
-  useUnfollowProfileUserMutation,
+  useFollowUserMutation,
   useGetUserByUserNameQuery,
-} from '@/entities/users/api/publicUsers.api'
+  useUnfollowUserMutation,
+} from '@/entities/users/api'
 
-export const useFollowUserState = (userName: string, userId: number) => {
-  const { data: followState } = useGetUserByUserNameQuery(userName, { skip: !userName })
-  const [followUser, { isLoading: isFollowingLoading }] = useFollowProfileUserMutation()
-  const [unfollowUser, { isLoading: isUnfollowingLoading }] = useUnfollowProfileUserMutation()
+type FollowUserStateOptions = {
+  enabled?: boolean
+}
+
+export const useFollowUserState = (
+  userName: string,
+  userId: number,
+  currentUserId?: number,
+  { enabled = true }: FollowUserStateOptions = {}
+) => {
+  const canQuery = enabled && Boolean(userName)
+  const canMutate = enabled && Boolean(userName) && Number.isInteger(userId) && userId > 0
+  const { data: followState } = useGetUserByUserNameQuery(userName, { skip: !canQuery })
+  const [followUser, { isLoading: isFollowingLoading }] = useFollowUserMutation()
+  const [unfollowUser, { isLoading: isUnfollowingLoading }] = useUnfollowUserMutation()
 
   const handleFollow = async () => {
-    await followUser({ selectedUserId: userId }).unwrap()
+    if (!canMutate) {
+      return
+    }
+
+    await followUser({ currentUserId, selectedUserId: userId, targetUserName: userName }).unwrap()
   }
 
   const handleUnfollow = async () => {
-    await unfollowUser(userId).unwrap()
+    if (!canMutate) {
+      return
+    }
+
+    await unfollowUser({ currentUserId, selectedUserId: userId, targetUserName: userName }).unwrap()
   }
 
   return {
     isFollowing: followState?.isFollowing ?? false,
-    followersCount: followState?.followersCount ?? 0,
-    followingCount: followState?.followingCount ?? 0,
+    followersCount: followState?.followersCount,
+    followingCount: followState?.followingCount,
+    publicationsCount: followState?.publicationsCount,
     isFollowPending: isFollowingLoading || isUnfollowingLoading,
     handleFollow,
     handleUnfollow,

--- a/src/features/feed/model/useFeedActions.test.tsx
+++ b/src/features/feed/model/useFeedActions.test.tsx
@@ -67,17 +67,25 @@ describe('useFeedActions', () => {
     expect(result.current.isFollowing(7)).toBe(true)
 
     await act(async () => {
-      await result.current.toggleFollow(7)
+      await result.current.toggleFollow({ userId: 7, userName: 'john' })
     })
 
-    expect(unfollowUser).toHaveBeenCalledWith({ currentUserId: 1, selectedUserId: 7 })
+    expect(unfollowUser).toHaveBeenCalledWith({
+      currentUserId: 1,
+      selectedUserId: 7,
+      targetUserName: 'john',
+    })
     expect(result.current.isFollowing(7)).toBe(false)
 
     await act(async () => {
-      await result.current.toggleFollow(7)
+      await result.current.toggleFollow({ userId: 7, userName: 'john' })
     })
 
-    expect(followUser).toHaveBeenCalledWith({ currentUserId: 1, selectedUserId: 7 })
+    expect(followUser).toHaveBeenCalledWith({
+      currentUserId: 1,
+      selectedUserId: 7,
+      targetUserName: 'john',
+    })
     expect(result.current.isFollowing(7)).toBe(true)
   })
 
@@ -87,7 +95,7 @@ describe('useFeedActions', () => {
     const { result } = renderHook(() => useFeedActions(), { wrapper })
 
     await act(async () => {
-      await result.current.toggleFollow(7)
+      await result.current.toggleFollow({ userId: 7, userName: 'john' })
     })
 
     expect(result.current.isFollowing(7)).toBe(true)
@@ -122,7 +130,7 @@ describe('useFeedActions', () => {
     const firstFeed = renderHook(() => useFeedActions(), { wrapper })
 
     await act(async () => {
-      await firstFeed.result.current.toggleFollow(7)
+      await firstFeed.result.current.toggleFollow({ userId: 7, userName: 'john' })
     })
 
     firstFeed.unmount()

--- a/src/features/feed/model/useFeedActions.ts
+++ b/src/features/feed/model/useFeedActions.ts
@@ -40,7 +40,7 @@ export const useFeedActions = () => {
   )
 
   const toggleFollow = useCallback(
-    async (userId: number) => {
+    async ({ userId, userName }: { userId: number; userName?: string }) => {
       if (!authUserIdHint || pendingUserIds.has(userId)) {
         return
       }
@@ -51,10 +51,18 @@ export const useFeedActions = () => {
 
       try {
         if (shouldUnfollow) {
-          await unfollowUser({ currentUserId: authUserIdHint, selectedUserId: userId }).unwrap()
+          await unfollowUser({
+            currentUserId: authUserIdHint,
+            selectedUserId: userId,
+            targetUserName: userName,
+          }).unwrap()
           dispatch(markUserUnfollowed(userId))
         } else {
-          await followUser({ currentUserId: authUserIdHint, selectedUserId: userId }).unwrap()
+          await followUser({
+            currentUserId: authUserIdHint,
+            selectedUserId: userId,
+            targetUserName: userName,
+          }).unwrap()
           dispatch(markUserFollowed(userId))
         }
       } catch {

--- a/src/features/feed/ui/Feed.test.tsx
+++ b/src/features/feed/ui/Feed.test.tsx
@@ -225,7 +225,7 @@ describe('Feed', () => {
     fireEvent.click(screen.getByText('Toggle 1'))
     fireEvent.click(screen.getByText('Copy 2'))
 
-    expect(toggleFollow).toHaveBeenCalledWith(2)
+    expect(toggleFollow).toHaveBeenCalledWith({ userId: 2, userName: 'user-2' })
     expect(copyPostLink).toHaveBeenCalledWith(3, 2)
   })
 })

--- a/src/features/feed/ui/Feed.tsx
+++ b/src/features/feed/ui/Feed.tsx
@@ -49,7 +49,7 @@ export function Feed() {
             post={post}
             isFollowing={isFollowing(post.ownerId)}
             isFollowPending={isFollowPending(post.ownerId)}
-            onToggleFollow={() => toggleFollow(post.ownerId)}
+            onToggleFollow={() => toggleFollow({ userId: post.ownerId, userName: post.userName })}
             onCopyLink={() => copyPostLink(post.ownerId, post.id)}
             currentUser={user ? { userId: user.userId, userName: user.name } : undefined}
           />

--- a/src/features/feed/ui/FeedPost/FeedPost.tsx
+++ b/src/features/feed/ui/FeedPost/FeedPost.tsx
@@ -39,7 +39,7 @@ export function FeedPost({
     <article className={s.post}>
       <header className={s.header}>
         <Avatar image={avatarOwner} size={36} alt={`${userName} avatar`} />
-        <Link href={APP_ROUTES.PROFILE.ID(ownerId)} className={s.authorLink}>
+        <Link href={APP_ROUTES.PROFILE.BY_USERNAME(userName)} className={s.authorLink}>
           <Typography variant={'bold_14'}>{userName}</Typography>
         </Link>
         <span className={s.separator} aria-hidden={'true'} />

--- a/src/features/feed/ui/FeedPost/FeedPostFooter/FeedPostFooter.tsx
+++ b/src/features/feed/ui/FeedPost/FeedPostFooter/FeedPostFooter.tsx
@@ -82,7 +82,7 @@ export function FeedPostFooter({ currentUser, post }: Props) {
         <Avatar image={post.avatarOwner} size={36} alt={`${post.userName} avatar`} />
 
         <Typography variant={'regular_14'} className={s.descriptionText}>
-          <Link href={APP_ROUTES.PROFILE.ID(post.ownerId)}>
+          <Link href={APP_ROUTES.PROFILE.BY_USERNAME(post.userName)}>
             <strong>{post.userName}</strong>
           </Link>
           {post.description}

--- a/src/shared/composites/InfiniteScrollTrigger/InfiniteScrollTrigger.tsx
+++ b/src/shared/composites/InfiniteScrollTrigger/InfiniteScrollTrigger.tsx
@@ -1,12 +1,15 @@
+import { RefObject } from 'react'
+
 import { useInfiniteScroll } from '@/shared/hooks'
 
 type Prop = {
   hasNextPage: boolean
   onLoadMore: () => void
+  rootRef?: RefObject<Element | null>
 }
 
-export const InfiniteScrollTrigger = ({ hasNextPage, onLoadMore }: Prop) => {
-  const { observerRef } = useInfiniteScroll({ hasNextPage, onLoadMore })
+export const InfiniteScrollTrigger = ({ hasNextPage, onLoadMore, rootRef }: Prop) => {
+  const { observerRef } = useInfiniteScroll({ hasNextPage, onLoadMore, rootRef })
 
   if (!hasNextPage) {
     return null

--- a/src/shared/constant/app-routes.ts
+++ b/src/shared/constant/app-routes.ts
@@ -23,6 +23,7 @@ export const APP_ROUTES = {
   },
 
   PROFILE: {
+    BY_USERNAME: (userName: string) => `/profile/${encodeURIComponent(userName)}`,
     ID: (id: number) => `/profile/${id}`,
     WITH_POST: (id: number, postId: number, from?: PostOpenSource) => {
       const params = new URLSearchParams({ postId: String(postId) })

--- a/src/shared/hooks/useInfiniteScroll.ts
+++ b/src/shared/hooks/useInfiniteScroll.ts
@@ -1,14 +1,16 @@
-import React, { useEffect } from 'react'
+import React, { RefObject, useEffect } from 'react'
 
 interface Props {
   hasNextPage: boolean
   onLoadMore: () => void
+  rootRef?: RefObject<Element | null>
   rootMargin?: string
   threshold?: number
 }
 
 export const useInfiniteScroll = ({
   hasNextPage,
+  rootRef,
   rootMargin = '100px',
   threshold = 0.1,
   onLoadMore,
@@ -26,7 +28,7 @@ export const useInfiniteScroll = ({
           onLoadMore()
         }
       },
-      { root: null, rootMargin, threshold }
+      { root: rootRef?.current ?? null, rootMargin, threshold }
     )
 
     const currentRef = observerRef.current
@@ -40,7 +42,7 @@ export const useInfiniteScroll = ({
         observer.unobserve(currentRef)
       }
     }
-  }, [onLoadMore, hasNextPage, rootMargin, threshold])
+  }, [onLoadMore, hasNextPage, rootMargin, rootRef, threshold])
 
   return { observerRef }
 }

--- a/src/widgets/ProfileWithPostLikes/index.tsx
+++ b/src/widgets/ProfileWithPostLikes/index.tsx
@@ -3,10 +3,29 @@
 import type { PostLikeActionProps } from '@/entities/posts/ui/PostModal/postModalLikeAction.types'
 
 import { Profile, type ProfileProps } from '@/entities/profile/ui'
+import { useGetUserByUserNameQuery } from '@/entities/users/api'
 import { LikeButton } from '@/features/postLikes/ui/LikeButton'
 import { useAuthUiState } from '@/features/posts/utils/useAuthUiState'
+import { Loading } from '@/shared/composites'
+import { APP_ROUTES } from '@/shared/constant'
+import { Typography } from '@/shared/ui'
+import Link from 'next/link'
 
 type ProfileWithPostLikesProps = Omit<ProfileProps, 'renderPostLikeAction'>
+
+type ProfileWithPostLikesByUserNameProps = {
+  userName: string
+}
+
+const USERNAME_PROFILE_PAGE_SIZE = 8
+
+const getErrorStatus = (error: unknown) => {
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    return (error as { status?: unknown }).status
+  }
+
+  return undefined
+}
 
 export const ProfileWithPostLikes = (props: Readonly<ProfileWithPostLikesProps>) => {
   const { user, isAuthUiLoading, isAuthenticatedUi } = useAuthUiState()
@@ -26,6 +45,80 @@ export const ProfileWithPostLikes = (props: Readonly<ProfileWithPostLikesProps>)
       {...props}
       postModalAuthState={{ user, isAuthUiLoading, isAuthenticatedUi }}
       renderPostLikeAction={renderPostLikeAction}
+    />
+  )
+}
+
+export const ProfileWithPostLikesByUserName = ({
+  userName,
+}: Readonly<ProfileWithPostLikesByUserNameProps>) => {
+  const authState = useAuthUiState()
+  const { data, error, isFetching, isLoading } = useGetUserByUserNameQuery(userName, {
+    skip: !authState.isAuthenticatedUi,
+  })
+
+  if (authState.isAuthUiLoading || isLoading || isFetching) {
+    return <Loading />
+  }
+
+  if (!authState.isAuthenticatedUi) {
+    return (
+      <div>
+        <Typography variant={'h2'}>Sign in to view this profile</Typography>
+        <Link href={APP_ROUTES.AUTH.LOGIN}>Sign In</Link>
+      </div>
+    )
+  }
+
+  const status = getErrorStatus(error)
+
+  if (status === 401) {
+    return (
+      <div>
+        <Typography variant={'h2'}>Sign in to view this profile</Typography>
+        <Link href={APP_ROUTES.AUTH.LOGIN}>Sign In</Link>
+      </div>
+    )
+  }
+
+  if (status === 404) {
+    return (
+      <div>
+        <h1>Profile not found</h1>
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div>
+        <h1>Server unavailable</h1>
+        <p>Please try again later.</p>
+      </div>
+    )
+  }
+
+  return (
+    <ProfileWithPostLikes
+      resolvedUserId={data.id}
+      profileDataServer={{
+        id: data.id,
+        userName: data.userName,
+        aboutMe: data.aboutMe,
+        avatars: data.avatars,
+        isFollowing: data.isFollowing,
+        isFollowedBy: data.isFollowedBy,
+        userMetadata: {
+          followers: data.followersCount,
+          following: data.followingCount,
+          publications: data.publicationsCount,
+        },
+      }}
+      postsDataServer={{
+        items: [],
+        pageSize: USERNAME_PROFILE_PAGE_SIZE,
+        totalCount: 0,
+      }}
     />
   )
 }

--- a/src/widgets/UserSearch/UserSearch.module.css
+++ b/src/widgets/UserSearch/UserSearch.module.css
@@ -1,9 +1,19 @@
 .pageContainer {
+  height: calc(100vh - 132px);
+  min-height: 0;
   padding: 20px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
+  overflow: hidden;
+}
+
+.searchHeader {
+  flex-shrink: 0;
+  width: 100%;
+  padding-bottom: 16px;
+  background: var(--color-dark-700);
 }
 
 .pageTitle {
@@ -14,14 +24,17 @@
 }
 
 .container {
+  flex: 1;
+  min-height: 0;
   width: 100%;
+  overflow-y: auto;
+  padding-right: 4px;
 }
 
 .resultsList {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-top: 16px;
 }
 
 .userRow {
@@ -97,7 +110,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: 16px;
 }
 
 .emptyPlaceholder {
@@ -109,21 +121,6 @@
   color: var(--color-light-900);
   text-align: center;
   margin-top: 84px;
-}
-
-.loadingMore {
-  padding: 16px;
-  text-align: center;
-  color: var(--color-light-900);
-  font-size: 14px;
-}
-
-.loadingInitial {
-  margin-top: 16px;
-  padding: 24px;
-  text-align: center;
-  color: var(--color-light-900);
-  font-size: 14px;
 }
 
 .errorMessage {

--- a/src/widgets/UserSearch/index.tsx
+++ b/src/widgets/UserSearch/index.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 
-import { SearchUserItem, SearchUsersResponse } from '@/entities/users/api/api.types'
+import { SearchUserItem } from '@/entities/users/api/api.types'
 import { publicUsersApi } from '@/entities/users/api/publicUsers.api'
 import { Avatar } from '@/shared/composites/Avatar/Avatar'
 import { InfiniteScrollTrigger } from '@/shared/composites/InfiniteScrollTrigger/InfiniteScrollTrigger'
+import { LinearProgress } from '@/shared/composites/LinearProgress'
+import { APP_ROUTES } from '@/shared/constant'
 import { Button, Close } from '@/shared/ui'
 import { Input } from '@/shared/ui/Input'
 import { Typography } from '@ictroot/ui-kit'
@@ -36,12 +38,14 @@ export const UserSearch = () => {
   const [recentUsers, setRecentUsers] = useState<SearchUserItem[]>([])
   const [allUsers, setAllUsers] = useState<SearchUserItem[]>([])
   const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [isLoadingInitial, setIsLoadingInitial] = useState(false)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
-  const [currentPage, setCurrentPage] = useState(1)
-  const [totalPages, setTotalPages] = useState(0)
+  const [isError, setIsError] = useState(false)
+  const isLoadingMoreRef = useRef(false)
+  const requestIdRef = useRef(0)
+  const resultsRootRef = useRef<HTMLDivElement | null>(null)
 
-  const [triggerSearch, { data: searchData, isLoading: isLoadingInitial, isError }] =
-    publicUsersApi.useLazySearchUsersQuery()
+  const [triggerSearch] = publicUsersApi.useLazySearchUsersQuery()
 
   useEffect(() => {
     setRecentUsers(readRecentUsers())
@@ -56,57 +60,91 @@ export const UserSearch = () => {
   }, [query])
 
   useEffect(() => {
+    const requestId = requestIdRef.current + 1
+
+    requestIdRef.current = requestId
+
     if (debouncedQuery) {
       setAllUsers([])
       setNextCursor(null)
-      setCurrentPage(1)
-      setTotalPages(0)
-      // Для первого запроса не передаем cursor
-      triggerSearch({ search: debouncedQuery, pageSize: PAGE_SIZE }, true)
+      setIsError(false)
+      setIsLoadingInitial(true)
+      setIsLoadingMore(false)
+      isLoadingMoreRef.current = false
+
+      triggerSearch({ search: debouncedQuery, pageSize: PAGE_SIZE })
+        .unwrap()
+        .then(data => {
+          if (requestIdRef.current !== requestId) {
+            return
+          }
+
+          setAllUsers(data.items)
+          setNextCursor(data.nextCursor > 0 ? data.nextCursor : null)
+        })
+        .catch(() => {
+          if (requestIdRef.current !== requestId) {
+            return
+          }
+
+          setAllUsers([])
+          setNextCursor(null)
+          setIsError(true)
+        })
+        .finally(() => {
+          if (requestIdRef.current === requestId) {
+            setIsLoadingInitial(false)
+          }
+        })
+
+      return
     }
+
+    setAllUsers([])
+    setNextCursor(null)
+    setIsError(false)
+    setIsLoadingInitial(false)
+    setIsLoadingMore(false)
+    isLoadingMoreRef.current = false
   }, [debouncedQuery, triggerSearch])
 
-  useEffect(() => {
-    if (searchData) {
-      // Обновляем состояние на основе полученных данных
-      setAllUsers(prev => {
-        // Для первой страницы просто устанавливаем данные
-        if (nextCursor === null) {
-          setCurrentPage(searchData.page)
-          setTotalPages(searchData.pagesCount)
-
-          return searchData.items
-        } else {
-          // Для последующих страниц проверяем на дубликаты
-          const existingIds = new Set(prev.map(item => item.id))
-          const newItems = searchData.items.filter(item => !existingIds.has(item.id))
-
-          return [...prev, ...newItems]
-        }
-      })
-
-      // Обновляем курсор для следующего запроса
-      setNextCursor(searchData.nextCursor > 0 ? searchData.nextCursor : null)
-      setCurrentPage(searchData.page)
-      setTotalPages(searchData.pagesCount)
-    }
-  }, [searchData])
-
   const loadMore = useCallback(() => {
-    if (debouncedQuery && nextCursor !== null && !isLoadingMore && !isLoadingInitial) {
+    if (debouncedQuery && nextCursor !== null && !isLoadingMoreRef.current && !isLoadingInitial) {
+      const requestId = requestIdRef.current
+
+      isLoadingMoreRef.current = true
       setIsLoadingMore(true)
 
-      triggerSearch({ search: debouncedQuery, pageSize: PAGE_SIZE, cursor: nextCursor }, true)
+      triggerSearch({ search: debouncedQuery, pageSize: PAGE_SIZE, cursor: nextCursor })
         .unwrap()
+        .then(data => {
+          if (requestIdRef.current !== requestId) {
+            return
+          }
+
+          setAllUsers(prev => {
+            const existingIds = new Set(prev.map(item => item.id))
+            const newItems = data.items.filter(item => !existingIds.has(item.id))
+
+            return [...prev, ...newItems]
+          })
+          setNextCursor(data.nextCursor > 0 ? data.nextCursor : null)
+        })
         .catch(() => {
-          // В случае ошибки сбрасываем курсор, чтобы не пытаться загружать снова
+          if (requestIdRef.current !== requestId) {
+            return
+          }
+
           setNextCursor(null)
         })
         .finally(() => {
-          setIsLoadingMore(false)
+          if (requestIdRef.current === requestId) {
+            setIsLoadingMore(false)
+            isLoadingMoreRef.current = false
+          }
         })
     }
-  }, [debouncedQuery, nextCursor, isLoadingMore, isLoadingInitial, triggerSearch])
+  }, [debouncedQuery, isLoadingInitial, nextCursor, triggerSearch])
 
   const hasMore = nextCursor !== null
 
@@ -147,7 +185,7 @@ export const UserSearch = () => {
   const renderUserItem = (user: SearchUserItem, removable = false) => (
     <div key={user.id} className={styles.userRow}>
       <Link
-        href={`/profile/${user.id}`}
+        href={APP_ROUTES.PROFILE.BY_USERNAME(user.userName)}
         className={styles.userItem}
         onClick={() => handleSelectUser(user)}
       >
@@ -178,14 +216,17 @@ export const UserSearch = () => {
 
   return (
     <div className={styles.pageContainer}>
-      <h2 className={styles.pageTitle}>Search</h2>
-      <div className={styles.container}>
+      <LinearProgress active={isLoadingInitial || isLoadingMore} />
+      <div className={styles.searchHeader}>
+        <h2 className={styles.pageTitle}>Search</h2>
         <Input
           placeholder={'Search users...'}
           value={query}
           onChange={e => setQuery(e.target.value)}
           inputType={'search'}
         />
+      </div>
+      <div className={styles.container} ref={resultsRootRef}>
         {showRecent ? (
           <>
             <div className={styles.recentHeader}>
@@ -209,22 +250,19 @@ export const UserSearch = () => {
           </>
         ) : (
           <>
-            {isLoadingInitial && allUsers.length === 0 && (
-              <div className={styles.loadingInitial}>Loading users...</div>
-            )}
-
             {isError && (
               <div className={styles.errorMessage}>Error during search. Please try again.</div>
             )}
 
             {allUsers.length > 0 && (
-              <>
-                <div className={styles.resultsList}>
-                  {allUsers.map(user => renderUserItem(user))}
-                  <InfiniteScrollTrigger hasNextPage={hasMore} onLoadMore={loadMore} />
-                  {isLoadingMore && <div className={styles.loadingMore}>Loading more users...</div>}
-                </div>
-              </>
+              <div className={styles.resultsList}>
+                {allUsers.map(user => renderUserItem(user))}
+                <InfiniteScrollTrigger
+                  hasNextPage={hasMore}
+                  onLoadMore={loadMore}
+                  rootRef={resultsRootRef}
+                />
+              </div>
             )}
 
             {debouncedQuery && allUsers.length === 0 && !isLoadingInitial && !isError && (


### PR DESCRIPTION
## Summary

- Jira: SCRUM-283
- What changed: fixed Search user flow and unified follow/unfollow behavior for Profile, Search navigation, Feed, and post modal surfaces.

## Scope

### In scope

- Search users by full or partial username.
- Search results and recent users navigate to `/profile/{userName}`.
- Username profile route resolves authenticated username to numeric user id while keeping username in the URL.
- Numeric `/profile/{id}` legacy SSR flow remains supported.
- Search results use stable cursor-based infinite scroll.
- Search loading states use linear progress instead of loading text.
- Follow/unfollow API was unified into one RTK Query endpoint pair.
- Follow/unfollow optimistic cache updates sync target followers count and current user following count.
- Feed unfollow keeps the post visible until reload and allows follow back.

### Out of scope

- Comments flow.
- Comment replies.
- Comment likes.
- Post likes implementation.
- Anonymous public username profile access, because backend has no public username profile endpoint.
- Cross-tab live synchronization of profile counters.

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

## Contract change

- What changed: N/A
- Why: N/A
- Impact/Migration: N/A
- Policy version updated: N/A

## Mandatory checklist

- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
  - `pnpm vitest run src/entities/users/api/usersFollow.api.test.ts src/features/feed/model/useFeedActions.test.tsx` - passed, 6 tests.
  - `pnpm run ci:check` - passed.
  - Known non-blocking warnings: existing `logger.ts` no-console warnings, autoprefixer warning in `CropStep.module.scss`, and build-time `ENOTFOUND inctagram.work`; command exits with code 0.

### Manual

- Scenario 1: Search -> enter username/partial username -> results appear -> scroll results -> next page loads without replacing current query results.
- Scenario 2: Search result click -> opens `/profile/{userName}` -> profile resolves -> Follow/Unfollow updates button and counters without page reload.
- Scenario 3: `/profile/{id}` still opens through numeric SSR flow.
- Scenario 4: Feed -> post context menu -> Unfollow -> post stays visible until reload -> Follow back is available.
- Scenario 5: Post modal/profile follow state remains consistent with unified follow API.

## Risks and Rollback

- Risks:
  - Search relevance for 1-2 characters still depends on backend search behavior.
  - `/profile/{userName}` is authenticated-only; anonymous username profile access requires backend support.
  - Counter sync is RTK Query cache-based inside one app runtime; separate browser tabs are not live-synced.
  - Search/profile username resolver currently has limited dedicated automated test coverage.

- Rollback plan:
  - Revert the Search/follow-sync commits from this branch.
  - Restore previous numeric profile links if username routing causes regressions.
  - Restore previous Feed follow action wiring if unified follow mutation causes production issues.