### PR TITLE
SCRUM-304 Messenger Data and Socket Foundation

### DIFF
--- a/src/entities/messenger/api/index.ts
+++ b/src/entities/messenger/api/index.ts
@@ -1,0 +1,1 @@
+export * from './messenger.api'

--- a/src/entities/messenger/api/messenger.api.test.ts
+++ b/src/entities/messenger/api/messenger.api.test.ts
@@ -1,0 +1,135 @@
+/* @vitest-environment node */
+
+import { API_ROUTES } from '@/shared/api'
+import { baseApi } from '@/shared/api/base-api'
+import { configureStore } from '@reduxjs/toolkit'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { messengerApi } from './messenger.api'
+
+const createTestStore = () =>
+  configureStore({
+    reducer: {
+      [baseApi.reducerPath]: baseApi.reducer,
+    },
+    middleware: getDefaultMiddleware => getDefaultMiddleware().concat(baseApi.middleware),
+  })
+
+const emptyResponse = {
+  pageSize: 12,
+  totalCount: 0,
+  notReadCount: 0,
+  items: [],
+}
+
+const asJsonResponse = () =>
+  new Response(JSON.stringify(emptyResponse), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+const asNoContentResponse = () => new Response(null, { status: 204 })
+
+const asRequest = (call: unknown[]) => {
+  const [input, init] = call as [Request | URL | string, RequestInit | undefined]
+
+  if (input instanceof Request) {
+    return input
+  }
+
+  return new Request(String(input), init)
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('messengerApi', () => {
+  it('requests messenger dialogs with query parameters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(asJsonResponse())
+    const store = createTestStore()
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch)
+
+    await store.dispatch(
+      messengerApi.endpoints.getMessengerDialogs.initiate({
+        cursor: 10,
+        pageSize: 20,
+        searchName: 'anna',
+      })
+    )
+
+    const request = asRequest(fetchMock.mock.calls[0])
+    const url = new URL(request.url)
+
+    expect(url.pathname.endsWith(API_ROUTES.MESSENGER.BASE)).toBe(true)
+    expect(request.method).toBe('GET')
+    expect(url.searchParams.get('cursor')).toBe('10')
+    expect(url.searchParams.get('pageSize')).toBe('20')
+    expect(url.searchParams.get('searchName')).toBe('anna')
+  })
+
+  it('requests messages of a selected dialogue', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(asJsonResponse())
+    const store = createTestStore()
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch)
+
+    await store.dispatch(
+      messengerApi.endpoints.getDialogueMessages.initiate({
+        dialoguePartnerId: 7,
+        cursor: 25,
+        pageSize: 12,
+      })
+    )
+
+    const request = asRequest(fetchMock.mock.calls[0])
+    const url = new URL(request.url)
+    const expectedPath = API_ROUTES.MESSENGER.DIALOGUE('7')
+
+    expect(url.pathname.endsWith(expectedPath)).toBe(true)
+    expect(request.method).toBe('GET')
+    expect(url.searchParams.get('cursor')).toBe('25')
+    expect(url.searchParams.get('pageSize')).toBe('12')
+    expect(url.searchParams.has('dialoguePartnerId')).toBe(false)
+  })
+
+  it('marks messages as read', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(asNoContentResponse())
+    const store = createTestStore()
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch)
+
+    await store.dispatch(
+      messengerApi.endpoints.markMessagesAsRead.initiate({
+        ids: [1, 2, 3],
+      })
+    )
+
+    const request = asRequest(fetchMock.mock.calls[0])
+    const url = new URL(request.url)
+
+    expect(url.pathname.endsWith(API_ROUTES.MESSENGER.BASE)).toBe(true)
+    expect(request.method).toBe('PUT')
+    await expect(request.json()).resolves.toEqual({
+      ids: [1, 2, 3],
+    })
+  })
+
+  it('deletes a message by id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(asNoContentResponse())
+    const store = createTestStore()
+
+    vi.stubGlobal('fetch', fetchMock as typeof fetch)
+
+    await store.dispatch(messengerApi.endpoints.deleteMessage.initiate(15))
+
+    const request = asRequest(fetchMock.mock.calls[0])
+    const url = new URL(request.url)
+    const expectedPath = API_ROUTES.MESSENGER.DELETE_MESSAGE(15)
+
+    expect(url.pathname.endsWith(expectedPath)).toBe(true)
+    expect(request.method).toBe('DELETE')
+    expect(request.body).toBeNull()
+  })
+})

--- a/src/entities/messenger/api/messenger.api.test.ts
+++ b/src/entities/messenger/api/messenger.api.test.ts
@@ -31,7 +31,11 @@ const asJsonResponse = () =>
 const asNoContentResponse = () => new Response(null, { status: 204 })
 
 const asRequest = (call: unknown[]) => {
-  const [input, init] = call as [Request | URL | string, RequestInit | undefined]
+  const [input, init] = call as [
+    Request | URL | string,
+    ConstructorParameters<typeof Request>[1],
+    undefined,
+  ]
 
   if (input instanceof Request) {
     return input

--- a/src/entities/messenger/api/messenger.api.ts
+++ b/src/entities/messenger/api/messenger.api.ts
@@ -1,0 +1,55 @@
+import type {
+  DialogueMessagesResponseDto,
+  GetDialogueMessagesParams,
+  GetMessengerDialogsParams,
+  MessengerDialogsResponseDto,
+  UpdateMessagesStatusDto,
+} from '@/entities/messenger/model'
+
+import { API_ROUTES } from '@/shared/api'
+import { baseApi } from '@/shared/api/base-api'
+
+export const messengerApi = baseApi.injectEndpoints({
+  endpoints: builder => ({
+    getMessengerDialogs: builder.query<MessengerDialogsResponseDto, GetMessengerDialogsParams>({
+      query: params => ({
+        url: API_ROUTES.MESSENGER.BASE,
+        params,
+      }),
+      providesTags: ['MessengerDialogs'],
+    }),
+    getDialogueMessages: builder.query<DialogueMessagesResponseDto, GetDialogueMessagesParams>({
+      query: ({ dialoguePartnerId, ...params }) => ({
+        url: API_ROUTES.MESSENGER.DIALOGUE(String(dialoguePartnerId)),
+        params,
+      }),
+      providesTags: (result, error, { dialoguePartnerId }) => [
+        { type: 'DialogueMessages', id: dialoguePartnerId },
+      ],
+    }),
+    markMessagesAsRead: builder.mutation<void, UpdateMessagesStatusDto>({
+      query: body => ({
+        url: API_ROUTES.MESSENGER.BASE,
+        method: 'PUT',
+        body,
+      }),
+      invalidatesTags: ['MessengerDialogs', 'DialogueMessages'],
+    }),
+    deleteMessage: builder.mutation<void, number>({
+      query: id => ({
+        url: API_ROUTES.MESSENGER.DELETE_MESSAGE(id),
+        method: 'DELETE',
+      }),
+      invalidatesTags: ['MessengerDialogs', 'DialogueMessages'],
+    }),
+  }),
+})
+
+export const {
+  useDeleteMessageMutation,
+  useGetDialogueMessagesQuery,
+  useGetMessengerDialogsQuery,
+  useLazyGetDialogueMessagesQuery,
+  useLazyGetMessengerDialogsQuery,
+  useMarkMessagesAsReadMutation,
+} = messengerApi

--- a/src/entities/messenger/index.ts
+++ b/src/entities/messenger/index.ts
@@ -1,0 +1,1 @@
+export * from './model'

--- a/src/entities/messenger/index.ts
+++ b/src/entities/messenger/index.ts
@@ -1,1 +1,2 @@
+export * from './api'
 export * from './model'

--- a/src/entities/messenger/index.ts
+++ b/src/entities/messenger/index.ts
@@ -1,2 +1,3 @@
 export * from './api'
+export * from './lib'
 export * from './model'

--- a/src/entities/messenger/lib/index.ts
+++ b/src/entities/messenger/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './map-message-to-dialogue-preview'
 export * from './normalize-messenger-error'
 export * from './validate-incoming-message'
+export * from './upsert-message-in-history'

--- a/src/entities/messenger/lib/index.ts
+++ b/src/entities/messenger/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './map-message-to-dialogue-preview'
+export * from './normalize-messenger-error'
+export * from './validate-incoming-message'

--- a/src/entities/messenger/lib/index.ts
+++ b/src/entities/messenger/lib/index.ts
@@ -1,4 +1,4 @@
 export * from './map-message-to-dialogue-preview'
 export * from './normalize-messenger-error'
-export * from './validate-incoming-message'
+export * from './is-incoming-message-payload'
 export * from './upsert-message-in-history'

--- a/src/entities/messenger/lib/is-incoming-message-payload.test.ts
+++ b/src/entities/messenger/lib/is-incoming-message-payload.test.ts
@@ -1,7 +1,7 @@
 import { MessageStatus, MessageType, type MessageViewModel } from '@/entities/messenger/model'
 import { describe, expect, it } from 'vitest'
 
-import { validateIncomingMessagePayload } from './validate-incoming-message'
+import { isIncomingMessagePayload } from './is-incoming-message-payload'
 
 const validPayload = {
   id: 10,
@@ -16,7 +16,7 @@ const validPayload = {
 
 describe('validateIncomingMessagePayload', () => {
   it('accepts a valid message', () => {
-    expect(validateIncomingMessagePayload(validPayload)).toBe(true)
+    expect(isIncomingMessagePayload(validPayload)).toBe(true)
   })
 
   it.each([
@@ -27,6 +27,6 @@ describe('validateIncomingMessagePayload', () => {
     ['invalid status', { ...validPayload, status: 'DELIVERED' }],
     ['invalid date', { ...validPayload, createdAt: 'invalid' }],
   ])('rejects %s', (_, payload) => {
-    expect(validateIncomingMessagePayload(payload)).toBe(false)
+    expect(isIncomingMessagePayload(payload)).toBe(false)
   })
 })

--- a/src/entities/messenger/lib/is-incoming-message-payload.ts
+++ b/src/entities/messenger/lib/is-incoming-message-payload.ts
@@ -15,7 +15,7 @@ const isMessageType = (value: unknown): value is MessageType =>
 const isMessageStatus = (value: unknown): value is MessageStatus =>
   Object.values(MessageStatus).some(status => status === value)
 
-export function validateIncomingMessagePayload(payload: unknown): payload is MessageViewModel {
+export function isIncomingMessagePayload(payload: unknown): payload is MessageViewModel {
   if (!isRecord(payload)) {
     return false
   }

--- a/src/entities/messenger/lib/map-message-to-dialogue-preview.test.ts
+++ b/src/entities/messenger/lib/map-message-to-dialogue-preview.test.ts
@@ -1,0 +1,121 @@
+import {
+  MessageStatus,
+  MessageType,
+  type LastMessageViewDto,
+  type MessageViewModel,
+} from '@/entities/messenger/model'
+import { describe, expect, it } from 'vitest'
+
+import { mapMessageToDialoguePreview } from './map-message-to-dialogue-preview'
+
+const CURRENT_USER_ID = 1
+const DATE = '2026-07-12T10:00:00.000Z'
+
+const createDialogue = (partnerId: number, userName: string): LastMessageViewDto => ({
+  id: partnerId * 10,
+  ownerId: partnerId,
+  receiverId: CURRENT_USER_ID,
+  messageText: `Old message from ${userName}`,
+  status: MessageStatus.READ,
+  messageType: MessageType.TEXT,
+  createdAt: DATE,
+  updatedAt: DATE,
+  userName,
+  avatars: [
+    {
+      url: `/${userName}.jpg`,
+      width: 100,
+      height: 100,
+      fileSize: 1000,
+    },
+  ],
+  notReadCount: 2,
+})
+
+const createMessage = (
+  ownerId: number,
+  receiverId: number,
+  messageText: string
+): MessageViewModel => ({
+  id: 100,
+  ownerId,
+  receiverId,
+  messageText,
+  status: MessageStatus.RECEIVED,
+  messageType: MessageType.TEXT,
+  createdAt: '2026-07-12T11:00:00.000Z',
+  updatedAt: '2026-07-12T11:00:00.000Z',
+})
+
+const annaDialogue = createDialogue(2, 'anna')
+const ivanDialogue = createDialogue(3, 'ivan')
+
+describe('mapMessageToDialoguePreview', () => {
+  it('updates and moves an outgoing dialogue to the top', () => {
+    const dialogues = [annaDialogue, ivanDialogue]
+    const originalDialogues = structuredClone(dialogues)
+    const message = createMessage(CURRENT_USER_ID, 3, 'New message to Ivan')
+
+    const result = mapMessageToDialoguePreview(dialogues, message, CURRENT_USER_ID)
+
+    expect(result.type).toBe('updated')
+
+    if (result.type !== 'updated') {
+      throw new Error('Expected updated result')
+    }
+
+    expect(result.dialogues.map(item => item.userName)).toEqual(['ivan', 'anna'])
+    expect(result.dialogues[0]).toMatchObject(message)
+    expect(result.dialogues[0].avatars).toBe(ivanDialogue.avatars)
+    expect(result.dialogues[0].notReadCount).toBe(2)
+    expect(dialogues).toEqual(originalDialogues)
+    expect(result.dialogues).not.toBe(dialogues)
+  })
+
+  it('finds an incoming dialogue by ownerId', () => {
+    const message = createMessage(2, CURRENT_USER_ID, 'New message from Anna')
+
+    const result = mapMessageToDialoguePreview(
+      [ivanDialogue, annaDialogue],
+      message,
+      CURRENT_USER_ID
+    )
+
+    expect(result.type).toBe('updated')
+
+    if (result.type !== 'updated') {
+      throw new Error('Expected updated result')
+    }
+
+    expect(result.dialogues[0].userName).toBe('anna')
+    expect(result.dialogues[0].messageText).toBe('New message from Anna')
+  })
+
+  it('returns dialogue-not-found for a new partner', () => {
+    const message = createMessage(4, CURRENT_USER_ID, 'Message from unknown partner')
+
+    const result = mapMessageToDialoguePreview(
+      [annaDialogue, ivanDialogue],
+      message,
+      CURRENT_USER_ID
+    )
+
+    expect(result).toEqual({
+      type: 'dialogue-not-found',
+    })
+  })
+
+  it('returns not-participant for an unrelated message', () => {
+    const message = createMessage(4, 5, 'Foreign message')
+
+    const result = mapMessageToDialoguePreview(
+      [annaDialogue, ivanDialogue],
+      message,
+      CURRENT_USER_ID
+    )
+
+    expect(result).toEqual({
+      type: 'not-participant',
+    })
+  })
+})

--- a/src/entities/messenger/lib/map-message-to-dialogue-preview.ts
+++ b/src/entities/messenger/lib/map-message-to-dialogue-preview.ts
@@ -1,0 +1,56 @@
+import type { LastMessageViewDto, MessageViewModel } from '@/entities/messenger/model'
+
+export type DialoguePreviewUpdateResult =
+  | {
+      type: 'updated'
+      dialogues: LastMessageViewDto[]
+    }
+  | {
+      type: 'dialogue-not-found'
+    }
+  | {
+      type: 'not-participant'
+    }
+
+function getDialoguePartnerId(message: MessageViewModel, currentUserId: number): number | null {
+  if (message.ownerId === currentUserId) {
+    return message.receiverId
+  }
+
+  if (message.receiverId === currentUserId) {
+    return message.ownerId
+  }
+
+  return null
+}
+
+export function mapMessageToDialoguePreview(
+  dialogues: readonly LastMessageViewDto[],
+  message: MessageViewModel,
+  currentUserId: number
+): DialoguePreviewUpdateResult {
+  const partnerId = getDialoguePartnerId(message, currentUserId)
+
+  if (partnerId === null) {
+    return { type: 'not-participant' }
+  }
+
+  const dialogueIndex = dialogues.findIndex(
+    dialogue => getDialoguePartnerId(dialogue, currentUserId) === partnerId
+  )
+
+  if (dialogueIndex === -1) {
+    return { type: 'dialogue-not-found' }
+  }
+
+  const currentDialogue = dialogues[dialogueIndex]
+  const updatedDialogue = {
+    ...currentDialogue,
+    ...message,
+  }
+
+  return {
+    type: 'updated',
+    dialogues: [updatedDialogue, ...dialogues.filter((_, index) => index !== dialogueIndex)],
+  }
+}

--- a/src/entities/messenger/lib/normalize-messenger-error.test.ts
+++ b/src/entities/messenger/lib/normalize-messenger-error.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeMessengerError } from './normalize-messenger-error'
+
+describe('normalizeMessengerError', () => {
+  it('normalizes a native Error', () => {
+    const result = normalizeMessengerError(new Error('Connection failed'), 'socket')
+
+    expect(result).toEqual({
+      source: 'socket',
+      code: 'SOCKET_ERROR',
+      message: 'Connection failed',
+    })
+  })
+
+  it('normalizes an HTTP API error', () => {
+    const result = normalizeMessengerError(
+      {
+        status: 404,
+        data: { message: 'Dialogue not found' },
+        error: 'Technical error',
+      },
+      'api'
+    )
+
+    expect(result).toEqual({
+      source: 'api',
+      code: '404',
+      message: 'Dialogue not found',
+    })
+  })
+
+  it('normalizes an RTK Query fetch error', () => {
+    const result = normalizeMessengerError(
+      {
+        status: 'FETCH_ERROR',
+        error: 'Failed to fetch',
+      },
+      'api'
+    )
+
+    expect(result).toEqual({
+      source: 'api',
+      code: 'FETCH_ERROR',
+      message: 'Failed to fetch',
+    })
+  })
+
+  it('normalizes a backend socket error DTO', () => {
+    const result = normalizeMessengerError(
+      {
+        error: 'DELIVERY_FAILED',
+        message: 'Cannot deliver message',
+      },
+      'socket'
+    )
+
+    expect(result).toEqual({
+      source: 'socket',
+      code: 'DELIVERY_FAILED',
+      message: 'Cannot deliver message',
+    })
+  })
+
+  it('prefers an explicit code over status', () => {
+    const result = normalizeMessengerError(
+      {
+        code: 'MESSAGE_FORBIDDEN',
+        status: 403,
+        message: 'Message is forbidden',
+      },
+      'api'
+    )
+
+    expect(result).toEqual({
+      source: 'api',
+      code: 'MESSAGE_FORBIDDEN',
+      message: 'Message is forbidden',
+    })
+  })
+
+  it.each([
+    ['api', null, 'API_ERROR'],
+    ['socket', undefined, 'SOCKET_ERROR'],
+    ['api', 42, 'API_ERROR'],
+  ] as const)('uses fallback for an unknown %s error', (source, error, expectedCode) => {
+    const result = normalizeMessengerError(error, source)
+
+    expect(result).toEqual({
+      source,
+      code: expectedCode,
+      message: 'Unknown messenger error',
+    })
+  })
+})

--- a/src/entities/messenger/lib/normalize-messenger-error.ts
+++ b/src/entities/messenger/lib/normalize-messenger-error.ts
@@ -1,0 +1,56 @@
+import type { MessengerError, MessengerErrorSource } from '@/entities/messenger/model'
+
+const FALLBACK_CODES: Record<MessengerErrorSource, string> = {
+  api: 'API_ERROR',
+  socket: 'SOCKET_ERROR',
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const readString = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null
+
+const readCode = (value: unknown): string | null =>
+  typeof value === 'string' || typeof value === 'number' ? String(value) : null
+
+export function normalizeMessengerError(
+  error: unknown,
+  source: MessengerErrorSource
+): MessengerError {
+  const fallbackCode = FALLBACK_CODES[source]
+
+  if (error instanceof Error) {
+    return {
+      source,
+      code: fallbackCode,
+      message: error.message,
+    }
+  }
+
+  if (!isRecord(error)) {
+    return {
+      source,
+      code: fallbackCode,
+      message: 'Unknown messenger error',
+    }
+  }
+
+  const data = isRecord(error.data) ? error.data : null
+  const message =
+    readString(error.message) ??
+    readString(data?.message) ??
+    readString(error.error) ??
+    'Unknown messenger error'
+  const code =
+    readCode(error.code) ??
+    readCode(error.status) ??
+    (source === 'socket' ? readCode(error.error) : null) ??
+    fallbackCode
+
+  return {
+    source,
+    code,
+    message,
+  }
+}

--- a/src/entities/messenger/lib/upsert-message-in-history.test.ts
+++ b/src/entities/messenger/lib/upsert-message-in-history.test.ts
@@ -1,0 +1,60 @@
+import { MessageStatus, MessageType, type MessageViewModel } from '@/entities/messenger/model'
+import { describe, expect, it } from 'vitest'
+
+import { upsertMessageInHistory } from './upsert-message-in-history'
+
+const createMessage = (id: number, status: MessageStatus, text = 'Message'): MessageViewModel => ({
+  id,
+  ownerId: 1,
+  receiverId: 2,
+  messageText: text,
+  status,
+  messageType: MessageType.TEXT,
+  createdAt: '2026-07-13T10:00:00.000Z',
+  updatedAt: '2026-07-13T10:00:00.000Z',
+})
+
+describe('upsertMessageInHistory', () => {
+  it('adds a message when its id is not in history', () => {
+    const existingMessage = createMessage(1, MessageStatus.READ)
+    const incomingMessage = createMessage(2, MessageStatus.SENT)
+    const messages = [existingMessage]
+
+    const result = upsertMessageInHistory(messages, incomingMessage)
+
+    expect(result).toHaveLength(2)
+    expect(result).toContainEqual(incomingMessage)
+    expect(messages).toEqual([existingMessage])
+    expect(result).not.toBe(messages)
+  })
+
+  it('replaces an existing message with the same id', () => {
+    const sentMessage = createMessage(10, MessageStatus.SENT, 'Hello')
+    const receivedMessage = {
+      ...sentMessage,
+      status: MessageStatus.RECEIVED,
+      updatedAt: '2026-07-13T10:01:00.000Z',
+    }
+
+    const result = upsertMessageInHistory([sentMessage], receivedMessage)
+
+    expect(result).toEqual([receivedMessage])
+    expect(result[0].status).toBe(MessageStatus.RECEIVED)
+  })
+
+  it('does not change messages with different ids', () => {
+    const firstMessage = createMessage(1, MessageStatus.READ)
+    const targetMessage = createMessage(2, MessageStatus.SENT)
+    const updatedMessage = {
+      ...targetMessage,
+      status: MessageStatus.RECEIVED,
+    }
+    const messages = [firstMessage, targetMessage]
+
+    const result = upsertMessageInHistory(messages, updatedMessage)
+
+    expect(result[0]).toBe(firstMessage)
+    expect(result[1]).toEqual(updatedMessage)
+    expect(messages[1]).toBe(targetMessage)
+  })
+})

--- a/src/entities/messenger/lib/upsert-message-in-history.ts
+++ b/src/entities/messenger/lib/upsert-message-in-history.ts
@@ -1,0 +1,14 @@
+import type { MessageViewModel } from '../model'
+
+export function upsertMessageInHistory(
+  messages: readonly MessageViewModel[],
+  incomingMessage: MessageViewModel
+): MessageViewModel[] {
+  const messageExists = messages.some(message => message.id === incomingMessage.id)
+
+  if (!messageExists) {
+    return [...messages, incomingMessage]
+  }
+
+  return messages.map(message => (message.id === incomingMessage.id ? incomingMessage : message))
+}

--- a/src/entities/messenger/lib/validate-incoming-message.test.ts
+++ b/src/entities/messenger/lib/validate-incoming-message.test.ts
@@ -1,0 +1,32 @@
+import { MessageStatus, MessageType, type MessageViewModel } from '@/entities/messenger/model'
+import { describe, expect, it } from 'vitest'
+
+import { validateIncomingMessagePayload } from './validate-incoming-message'
+
+const validPayload = {
+  id: 10,
+  ownerId: 1,
+  receiverId: 2,
+  messageText: 'Hello',
+  status: MessageStatus.SENT,
+  messageType: MessageType.TEXT,
+  createdAt: '2026-07-12T10:00:00.000Z',
+  updatedAt: '2026-07-12T10:00:00.000Z',
+} satisfies MessageViewModel
+
+describe('validateIncomingMessagePayload', () => {
+  it('accepts a valid message', () => {
+    expect(validateIncomingMessagePayload(validPayload)).toBe(true)
+  })
+
+  it.each([
+    ['null payload', null],
+    ['invalid id', { ...validPayload, id: '10' }],
+    ['missing field', { ...validPayload, ownerId: undefined }],
+    ['invalid type', { ...validPayload, messageType: 'GIF' }],
+    ['invalid status', { ...validPayload, status: 'DELIVERED' }],
+    ['invalid date', { ...validPayload, createdAt: 'invalid' }],
+  ])('rejects %s', (_, payload) => {
+    expect(validateIncomingMessagePayload(payload)).toBe(false)
+  })
+})

--- a/src/entities/messenger/lib/validate-incoming-message.ts
+++ b/src/entities/messenger/lib/validate-incoming-message.ts
@@ -1,4 +1,4 @@
-import { MessageStatus, MessageType, type MessageViewModel } from '@/entities/messenger/model'
+import { MessageStatus, MessageType, type MessageViewModel } from '../model/messenger.types'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null

--- a/src/entities/messenger/lib/validate-incoming-message.ts
+++ b/src/entities/messenger/lib/validate-incoming-message.ts
@@ -1,0 +1,33 @@
+import { MessageStatus, MessageType, type MessageViewModel } from '@/entities/messenger/model'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const isInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value)
+
+const isDateString = (value: unknown): value is string =>
+  typeof value === 'string' && !Number.isNaN(Date.parse(value))
+
+const isMessageType = (value: unknown): value is MessageType =>
+  Object.values(MessageType).some(type => type === value)
+
+const isMessageStatus = (value: unknown): value is MessageStatus =>
+  Object.values(MessageStatus).some(status => status === value)
+
+export function validateIncomingMessagePayload(payload: unknown): payload is MessageViewModel {
+  if (!isRecord(payload)) {
+    return false
+  }
+
+  return (
+    isInteger(payload.id) &&
+    isInteger(payload.ownerId) &&
+    isInteger(payload.receiverId) &&
+    typeof payload.messageText === 'string' &&
+    isMessageStatus(payload.status) &&
+    isMessageType(payload.messageType) &&
+    isDateString(payload.createdAt) &&
+    isDateString(payload.updatedAt)
+  )
+}

--- a/src/entities/messenger/model/index.ts
+++ b/src/entities/messenger/model/index.ts
@@ -1,0 +1,1 @@
+export * from './messenger.types'

--- a/src/entities/messenger/model/index.ts
+++ b/src/entities/messenger/model/index.ts
@@ -1,1 +1,2 @@
+export * from './messenger.events'
 export * from './messenger.types'

--- a/src/entities/messenger/model/index.ts
+++ b/src/entities/messenger/model/index.ts
@@ -1,2 +1,4 @@
 export * from './messenger.events'
 export * from './messenger.types'
+export * from './messenger-socket.types'
+export * from './useMessengerSocket'

--- a/src/entities/messenger/model/messenger-socket.types.ts
+++ b/src/entities/messenger/model/messenger-socket.types.ts
@@ -1,0 +1,14 @@
+import type { MessageViewModel, MessengerError, SendMessagePayload } from './messenger.types'
+
+export type MessengerMessageHandler = (message: MessageViewModel) => Promise<void> | void
+
+export interface UseMessengerSocketOptions {
+  accessToken: null | string
+  onError: (error: MessengerError) => void
+  onMessage: MessengerMessageHandler
+}
+
+export interface UseMessengerSocketResult {
+  isConnected: boolean
+  sendMessage: (payload: SendMessagePayload) => void
+}

--- a/src/entities/messenger/model/messenger.events.ts
+++ b/src/entities/messenger/model/messenger.events.ts
@@ -1,0 +1,7 @@
+export const MESSENGER_SOCKET_EVENTS = {
+  RECEIVE_MESSAGE: 'receive-message',
+  UPDATE_MESSAGE: 'update-message',
+  MESSAGE_DELETED: 'message-deleted',
+  MESSAGE_SEND: 'message-send',
+  ERROR: 'error',
+} as const

--- a/src/entities/messenger/model/messenger.types.ts
+++ b/src/entities/messenger/model/messenger.types.ts
@@ -32,3 +32,44 @@ export interface LastMessageViewDto extends MessageViewModel {
 export interface UpdateMessagesStatusDto {
   ids: number[]
 }
+
+export interface GetMessengerDialogsParams {
+  cursor?: number
+  pageSize?: number
+  searchName?: string
+}
+export interface MessengerDialogsResponseDto {
+  pageSize: number
+  totalCount: number
+  notReadCount: number
+  items: LastMessageViewDto[]
+}
+
+export interface GetDialogueMessagesParams {
+  dialoguePartnerId: number
+  cursor?: number
+  pageSize?: number
+  searchName?: string
+}
+
+export interface DialogueMessagesResponseDto {
+  pageSize: number
+  totalCount: number
+  notReadCount: number
+  items: MessageViewModel[]
+}
+
+export interface SendMessagePayload {
+  message: string
+  receiverId: number
+}
+
+export interface UpdateMessagePayload {
+  id: number
+  message: string
+}
+
+export interface MessengerSocketErrorDto {
+  message: string
+  error: string
+}

--- a/src/entities/messenger/model/messenger.types.ts
+++ b/src/entities/messenger/model/messenger.types.ts
@@ -69,7 +69,17 @@ export interface UpdateMessagePayload {
   message: string
 }
 
+export type MessageAcknowledgement = (payload: SendMessagePayload) => void
+
 export interface MessengerSocketErrorDto {
   message: string
   error: string
+}
+
+export type MessengerErrorSource = 'api' | 'socket' | 'validation'
+
+export interface MessengerError {
+  source: MessengerErrorSource
+  code: string
+  message: string
 }

--- a/src/entities/messenger/model/messenger.types.ts
+++ b/src/entities/messenger/model/messenger.types.ts
@@ -1,20 +1,32 @@
-import { AvatarViewDto } from '../base/common'
-import { MessageType, MessageStatus } from '../base/enums'
+import type { AvatarViewDto } from '@/shared/types/base/common'
+
+export enum MessageType {
+  TEXT = 'TEXT',
+  IMAGE = 'IMAGE',
+  VOICE = 'VOICE',
+}
+
+export enum MessageStatus {
+  SENT = 'SENT',
+  RECEIVED = 'RECEIVED',
+  READ = 'READ',
+}
 
 export interface MessageViewModel {
   id: number
   ownerId: number
   receiverId: number
   messageText: string
+  status: MessageStatus
+  messageType: MessageType
   createdAt: string
   updatedAt: string
-  messageType: MessageType
-  status: MessageStatus
 }
 
 export interface LastMessageViewDto extends MessageViewModel {
   userName: string
   avatars: AvatarViewDto[]
+  notReadCount: number
 }
 
 export interface UpdateMessagesStatusDto {

--- a/src/entities/messenger/model/messenger.types.ts
+++ b/src/entities/messenger/model/messenger.types.ts
@@ -76,7 +76,7 @@ export interface MessengerSocketErrorDto {
   error: string
 }
 
-export type MessengerErrorSource = 'api' | 'socket' | 'validation'
+export type MessengerErrorSource = 'api' | 'socket'
 
 export interface MessengerError {
   source: MessengerErrorSource

--- a/src/entities/messenger/model/useMessengerSocket.test.ts
+++ b/src/entities/messenger/model/useMessengerSocket.test.ts
@@ -1,0 +1,303 @@
+/* eslint-disable max-lines */
+/* @vitest-environment jsdom */
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MESSENGER_SOCKET_EVENTS } from './messenger.events'
+import { MessageStatus, MessageType, type MessageViewModel } from './messenger.types'
+import { useMessengerSocket } from './useMessengerSocket'
+
+type SocketHandler = (...args: unknown[]) => void
+
+const { handlers, ioMock, socketMock } = vi.hoisted(() => {
+  const handlers = new Map<string, SocketHandler>()
+
+  const socketMock = {
+    connected: false,
+    disconnect: vi.fn(),
+    emit: vi.fn(),
+    off: vi.fn((event: string, handler: SocketHandler) => {
+      if (handlers.get(event) === handler) {
+        handlers.delete(event)
+      }
+    }),
+    on: vi.fn((event: string, handler: SocketHandler) => {
+      handlers.set(event, handler)
+    }),
+  }
+
+  return {
+    handlers,
+    ioMock: vi.fn(() => socketMock),
+    socketMock,
+  }
+})
+
+vi.mock('socket.io-client', () => ({
+  io: ioMock,
+}))
+
+vi.mock('@/shared/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}))
+
+beforeEach(() => {
+  handlers.clear()
+  socketMock.connected = false
+  vi.clearAllMocks()
+})
+
+const triggerSocketEvent = (event: string, ...args: unknown[]) => {
+  const handler = handlers.get(event)
+
+  if (!handler) {
+    throw new Error(`Missing handler for ${event}`)
+  }
+
+  handler(...args)
+}
+
+const setupHook = (accessToken: null | string = 'access-token') => {
+  const onError = vi.fn()
+  const onMessage = vi.fn()
+
+  const hook = renderHook(() =>
+    useMessengerSocket({
+      accessToken,
+      onError,
+      onMessage,
+    })
+  )
+
+  return {
+    ...hook,
+    onError,
+    onMessage,
+  }
+}
+
+const validMessage = {
+  id: 10,
+  ownerId: 2,
+  receiverId: 1,
+  messageText: 'Hello',
+  status: MessageStatus.SENT,
+  messageType: MessageType.TEXT,
+  createdAt: '2026-07-12T10:00:00.000Z',
+  updatedAt: '2026-07-12T10:00:00.000Z',
+} satisfies MessageViewModel
+
+describe('useMessengerSocket', () => {
+  it('does not connect without an access token', () => {
+    setupHook(null)
+
+    expect(ioMock).not.toHaveBeenCalled()
+  })
+
+  it('connects with the access token', () => {
+    setupHook()
+
+    expect(ioMock).toHaveBeenCalledWith('https://inctagram.work', {
+      query: {
+        accessToken: 'access-token',
+      },
+      autoConnect: true,
+      reconnection: true,
+      transports: ['websocket'],
+    })
+  })
+
+  it('updates the connection state', () => {
+    const { result } = setupHook()
+
+    expect(result.current.isConnected).toBe(false)
+
+    act(() => {
+      socketMock.connected = true
+      triggerSocketEvent('connect')
+    })
+
+    expect(result.current.isConnected).toBe(true)
+
+    act(() => {
+      socketMock.connected = false
+      triggerSocketEvent('disconnect')
+    })
+
+    expect(result.current.isConnected).toBe(false)
+  })
+
+  it('emits a message when connected', () => {
+    socketMock.connected = true
+    const { result } = setupHook()
+    const payload = {
+      message: 'Hello',
+      receiverId: 2,
+    }
+
+    act(() => {
+      result.current.sendMessage(payload)
+    })
+
+    expect(socketMock.emit).toHaveBeenCalledWith(MESSENGER_SOCKET_EVENTS.RECEIVE_MESSAGE, payload)
+  })
+
+  it('reports an error when sending while disconnected', () => {
+    const { onError, result } = setupHook()
+
+    act(() => {
+      result.current.sendMessage({
+        message: 'Hello',
+        receiverId: 2,
+      })
+    })
+
+    expect(socketMock.emit).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith({
+      source: 'socket',
+      code: 'SOCKET_NOT_CONNECTED',
+      message: 'Messenger socket is not connected',
+    })
+  })
+
+  it('processes a valid receive-message event', async () => {
+    const { onMessage } = setupHook()
+
+    act(() => {
+      triggerSocketEvent(MESSENGER_SOCKET_EVENTS.RECEIVE_MESSAGE, validMessage)
+    })
+
+    await waitFor(() => {
+      expect(onMessage).toHaveBeenCalledWith(validMessage)
+    })
+  })
+
+  it('acknowledges a successfully processed message', async () => {
+    const acknowledge = vi.fn()
+    const { onMessage } = setupHook()
+
+    act(() => {
+      triggerSocketEvent(MESSENGER_SOCKET_EVENTS.MESSAGE_SEND, validMessage, acknowledge)
+    })
+
+    await waitFor(() => {
+      expect(acknowledge).toHaveBeenCalledWith({
+        message: validMessage.messageText,
+        receiverId: validMessage.receiverId,
+      })
+    })
+
+    expect(onMessage).toHaveBeenCalledWith(validMessage)
+    expect(onMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      acknowledge.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('rejects an invalid incoming payload', async () => {
+    const acknowledge = vi.fn()
+    const { onError, onMessage } = setupHook()
+
+    act(() => {
+      triggerSocketEvent(MESSENGER_SOCKET_EVENTS.MESSAGE_SEND, { id: 'invalid' }, acknowledge)
+    })
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith({
+        source: 'socket',
+        code: 'INVALID_MESSAGE_PAYLOAD',
+        message: 'Invalid incoming message payload',
+      })
+    })
+
+    expect(onMessage).not.toHaveBeenCalled()
+    expect(acknowledge).not.toHaveBeenCalled()
+  })
+
+  it('does not acknowledge when message processing fails', async () => {
+    const acknowledge = vi.fn()
+    const { onError, onMessage } = setupHook()
+
+    onMessage.mockRejectedValueOnce(new Error('Cache update failed'))
+
+    act(() => {
+      triggerSocketEvent(MESSENGER_SOCKET_EVENTS.MESSAGE_SEND, validMessage, acknowledge)
+    })
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith({
+        source: 'socket',
+        code: 'SOCKET_ERROR',
+        message: 'Cache update failed',
+      })
+    })
+
+    expect(acknowledge).not.toHaveBeenCalled()
+  })
+
+  it('normalizes a socket error event', () => {
+    const { onError } = setupHook()
+
+    act(() => {
+      triggerSocketEvent(MESSENGER_SOCKET_EVENTS.ERROR, {
+        error: 'DELIVERY_FAILED',
+        message: 'Cannot deliver message',
+      })
+    })
+
+    expect(onError).toHaveBeenCalledWith({
+      source: 'socket',
+      code: 'DELIVERY_FAILED',
+      message: 'Cannot deliver message',
+    })
+  })
+
+  it('removes listeners and disconnects on unmount', () => {
+    const { unmount } = setupHook()
+
+    expect(handlers.size).toBe(6)
+
+    unmount()
+
+    expect(socketMock.off).toHaveBeenCalledTimes(6)
+    expect(socketMock.disconnect).toHaveBeenCalledOnce()
+    expect(handlers.size).toBe(0)
+  })
+
+  it('reconnects when the access token changes', () => {
+    const onError = vi.fn()
+    const onMessage = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ accessToken }: { accessToken: string }) =>
+        useMessengerSocket({
+          accessToken,
+          onError,
+          onMessage,
+        }),
+      {
+        initialProps: {
+          accessToken: 'old-token',
+        },
+      }
+    )
+
+    rerender({
+      accessToken: 'new-token',
+    })
+
+    expect(socketMock.disconnect).toHaveBeenCalledOnce()
+    expect(ioMock).toHaveBeenCalledTimes(2)
+    expect(ioMock).toHaveBeenNthCalledWith(
+      2,
+      'https://inctagram.work',
+      expect.objectContaining({
+        query: {
+          accessToken: 'new-token',
+        },
+      })
+    )
+  })
+})

--- a/src/entities/messenger/model/useMessengerSocket.ts
+++ b/src/entities/messenger/model/useMessengerSocket.ts
@@ -10,7 +10,7 @@ import type { UseMessengerSocketOptions, UseMessengerSocketResult } from './mess
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { normalizeMessengerError, validateIncomingMessagePayload } from '@/entities/messenger/lib'
+import { normalizeMessengerError, isIncomingMessagePayload } from '@/entities/messenger/lib'
 import { logger } from '@/shared/lib/logger'
 import { io, type Socket } from 'socket.io-client'
 
@@ -79,7 +79,7 @@ export function useMessengerSocket({
     }
 
     const processMessage = async (payload: unknown): Promise<MessageViewModel | null> => {
-      if (!validateIncomingMessagePayload(payload)) {
+      if (!isIncomingMessagePayload(payload)) {
         reportError({
           source: 'socket',
           code: 'INVALID_MESSAGE_PAYLOAD',

--- a/src/entities/messenger/model/useMessengerSocket.ts
+++ b/src/entities/messenger/model/useMessengerSocket.ts
@@ -1,0 +1,159 @@
+'use client'
+
+import type {
+  MessageAcknowledgement,
+  MessageViewModel,
+  MessengerError,
+  SendMessagePayload,
+} from './messenger.types'
+import type { UseMessengerSocketOptions, UseMessengerSocketResult } from './messenger-socket.types'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { normalizeMessengerError, validateIncomingMessagePayload } from '@/entities/messenger/lib'
+import { logger } from '@/shared/lib/logger'
+import { io, type Socket } from 'socket.io-client'
+
+import { MESSENGER_SOCKET_EVENTS } from './messenger.events'
+
+const WS_URL = 'https://inctagram.work'
+
+export function useMessengerSocket({
+  accessToken,
+  onError,
+  onMessage,
+}: UseMessengerSocketOptions): UseMessengerSocketResult {
+  const socketRef = useRef<Socket | null>(null)
+  const onErrorRef = useRef(onError)
+  const onMessageRef = useRef(onMessage)
+  const [isConnected, setIsConnected] = useState(false)
+
+  useEffect(() => {
+    onErrorRef.current = onError
+  }, [onError])
+
+  useEffect(() => {
+    onMessageRef.current = onMessage
+  }, [onMessage])
+
+  const sendMessage = useCallback((payload: SendMessagePayload) => {
+    const socket = socketRef.current
+
+    if (!socket?.connected) {
+      const error: MessengerError = {
+        source: 'socket',
+        code: 'SOCKET_NOT_CONNECTED',
+        message: 'Messenger socket is not connected',
+      }
+
+      logger.error('[MessengerSocket]', error.message)
+      onErrorRef.current(error)
+
+      return
+    }
+
+    socket.emit(MESSENGER_SOCKET_EVENTS.RECEIVE_MESSAGE, payload)
+  }, [])
+
+  useEffect(() => {
+    if (!accessToken) {
+      setIsConnected(false)
+
+      return
+    }
+
+    setIsConnected(false)
+
+    const socket = io(WS_URL, {
+      query: { accessToken },
+      autoConnect: true,
+      reconnection: true,
+      transports: ['websocket'],
+    })
+
+    socketRef.current = socket
+
+    const reportError = (error: MessengerError) => {
+      logger.error(`[MessengerSocket] ${error.code}:`, error.message)
+      onErrorRef.current(error)
+    }
+
+    const processMessage = async (payload: unknown): Promise<MessageViewModel | null> => {
+      if (!validateIncomingMessagePayload(payload)) {
+        reportError({
+          source: 'socket',
+          code: 'INVALID_MESSAGE_PAYLOAD',
+          message: 'Invalid incoming message payload',
+        })
+
+        return null
+      }
+
+      try {
+        await onMessageRef.current(payload)
+
+        return payload
+      } catch (error) {
+        reportError(normalizeMessengerError(error, 'socket'))
+
+        return null
+      }
+    }
+
+    const handleReceivedMessage = (payload: unknown) => {
+      void processMessage(payload)
+    }
+
+    const handleIncomingMessage = (payload: unknown, acknowledge?: MessageAcknowledgement) => {
+      void processMessage(payload)
+        .then(message => {
+          if (!message) {
+            return
+          }
+
+          acknowledge?.({
+            message: message.messageText,
+            receiverId: message.receiverId,
+          })
+        })
+        .catch(error => {
+          reportError(normalizeMessengerError(error, 'socket'))
+        })
+    }
+
+    const handleConnect = () => {
+      setIsConnected(true)
+    }
+
+    const handleDisconnect = () => {
+      setIsConnected(false)
+    }
+
+    const handleSocketError = (error: unknown) => {
+      reportError(normalizeMessengerError(error, 'socket'))
+    }
+
+    socket.on('connect', handleConnect)
+    socket.on('disconnect', handleDisconnect)
+    socket.on(MESSENGER_SOCKET_EVENTS.RECEIVE_MESSAGE, handleReceivedMessage)
+    socket.on(MESSENGER_SOCKET_EVENTS.MESSAGE_SEND, handleIncomingMessage)
+    socket.on(MESSENGER_SOCKET_EVENTS.ERROR, handleSocketError)
+    socket.on('connect_error', handleSocketError)
+
+    return () => {
+      socket.off('connect', handleConnect)
+      socket.off('disconnect', handleDisconnect)
+      socket.off(MESSENGER_SOCKET_EVENTS.RECEIVE_MESSAGE, handleReceivedMessage)
+      socket.off(MESSENGER_SOCKET_EVENTS.MESSAGE_SEND, handleIncomingMessage)
+      socket.off(MESSENGER_SOCKET_EVENTS.ERROR, handleSocketError)
+      socket.off('connect_error', handleSocketError)
+      socket.disconnect()
+
+      if (socketRef.current === socket) {
+        socketRef.current = null
+      }
+    }
+  }, [accessToken])
+
+  return { isConnected, sendMessage }
+}

--- a/src/shared/api/api-routes.ts
+++ b/src/shared/api/api-routes.ts
@@ -28,7 +28,7 @@ export const API_ROUTES = {
   MESSENGER: {
     BASE: '/v1/messenger',
     DIALOGUE: (dialoguePartnerId: string) => `/v1/messenger/${dialoguePartnerId}`,
-    DELETE_MESSAGE: (id: string) => `/v1/messenger/${id}`,
+    DELETE_MESSAGE: (id: number) => `/v1/messenger/${id}`,
   },
 
   NOTIFICATIONS: {

--- a/src/shared/api/base-api.ts
+++ b/src/shared/api/base-api.ts
@@ -22,6 +22,8 @@ export const baseApi = createApi({
     'Countries',
     'Notifications',
     'FollowersFeed',
+    'MessengerDialogs',
+    'DialogueMessages',
   ],
 })
 

--- a/src/shared/types/base/enums.ts
+++ b/src/shared/types/base/enums.ts
@@ -1,15 +1,3 @@
-export enum MessageType {
-  TEXT = 'TEXT',
-  IMAGE = 'IMAGE',
-  VOICE = 'VOICE',
-}
-
-export enum MessageStatus {
-  SENT = 'SENT',
-  RECEIVED = 'RECEIVED',
-  READ = 'READ',
-}
-
 export enum LikeStatus {
   NONE = 'NONE',
   LIKE = 'LIKE',

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,7 +2,6 @@ export * from './base/enums'
 
 export * from './auth/dto'
 export * from './user/models'
-export * from './messages/message.models'
 export * from './notifications/notification.models'
 export * from './comments'
 export * from './posts/models'


### PR DESCRIPTION
# SCRUM-304 — Messenger Data + Socket Foundation.

Подготовлен общий REST/WebSocket-слой Messenger, который другие разработчики смогут использовать для загрузки диалогов, получения истории и отправки текстовых сообщений без создания дополнительных API- и socket-клиентов.

## Что реализовано

### REST API

Добавлены RTK Query endpoints:

- `GET /v1/messenger` — получение списка диалогов;
- `GET /v1/messenger/{dialoguePartnerId}` — получение истории диалога;
- `PUT /v1/messenger` — обновление статуса сообщений;
- `DELETE /v1/messenger/{id}` — удаление сообщения.

Добавлены cache tags:

- `MessengerDialogs`;
- `DialogueMessages`.

### Типы

Типы Messenger перенесены из `shared/types` в `entities/messenger`:

- `MessageType`;
- `MessageStatus`;
- `MessageViewModel`;
- `LastMessageViewDto`;
- `SendMessagePayload`;
- типы REST API;
- типы socket callbacks;
- единый формат `MessengerError`.

### Socket.IO

Добавлен `useMessengerSocket`, который:

- подключается с использованием `accessToken`;
- предоставляет общий `sendMessage(payload)`;
- слушает `receive-message`, `message-send` и `error`;
- валидирует входящие сообщения;
- вызывает `onMessage` после успешной валидации;
- вызывает acknowledgement callback для входящего сообщения;
- нормализует socket-ошибки;
- обновляет состояние подключения;
- пересоздаёт соединение при смене токена;
- удаляет listeners и отключает socket при unmount.

### Pure-функции

Добавлены:

- `isIncomingMessagePayload` — runtime type guard, который проверяет структуру входящих данных от backend и сужает тип до `MessageViewModel`;
- `mapMessageToDialoguePreview` — обновление preview и перемещение диалога в начало списка;
- `upsertMessageInHistory` — добавление нового сообщения или обновление существующего по `id`;
- `normalizeMessengerError` — единый формат API/socket ошибок.

`upsertMessageInHistory` позволяет обрабатывать обновления статуса одного сообщения:

```text
SENT → RECEIVED → READ
```

без появления дубликатов в истории.

## Integration contract

`useMessengerSocket` должен подключаться один раз в общем Messenger shell/controller.

Дочерние text/image/voice features должны получать `sendMessage` через props или context и не должны создавать собственные socket-соединения.

Обработчик `onMessage` на стороне Messenger controller должен:

- обновлять историю через `upsertMessageInHistory`;
- обновлять список диалогов через `mapMessageToDialoguePreview`;
- при необходимости обновлять или инвалидировать RTK Query cache.

## Backend limitations

На текущий момент backend поддерживает через WebSocket только текстовые сообщения.

Контракты для image и voice сообщений отсутствуют:

- не определены endpoints загрузки файлов;
- не определён socket payload;
- не определён способ передачи `messageType`;
- не определён формат image/voice данных в `MessageViewModel`.

Поэтому:

- `SendMessagePayload` содержит только `message` и `receiverId`;
- image/voice integration заблокирована backend-контрактом;
- `MessageDraft` отложен до согласования общего media/composer-контракта.

## Тестирование

Добавлены тесты для:

- Messenger REST API;
- `useMessengerSocket`;
- `isIncomingMessagePayload`;
- error normalization;
- dialogue preview mapper;
- обновления сообщений в истории.