### PR TITLE
SCRUM-308 add followers and following lists

### DIFF
--- a/src/entities/profile/ui/Profile/FollowListModal/FollowListFeedback.tsx
+++ b/src/entities/profile/ui/Profile/FollowListModal/FollowListFeedback.tsx
@@ -1,0 +1,39 @@
+import { Button, Typography } from '@/shared/ui'
+
+import s from './FollowListModal.module.scss'
+
+type Props = {
+  emptyText?: string
+  onRetry?: () => void
+  type: 'empty' | 'error' | 'loading'
+}
+
+export const FollowListFeedback = ({ emptyText, onRetry, type }: Props) => {
+  if (type === 'loading') {
+    return (
+      <div className={s.state}>
+        <Typography variant={'regular_16'}>Loading users...</Typography>
+      </div>
+    )
+  }
+
+  if (type === 'error') {
+    return (
+      <div className={s.state}>
+        <Typography variant={'h3'}>Failed to load users</Typography>
+        <Typography className={s.stateText} variant={'regular_14'}>
+          Please try again.
+        </Typography>
+        <Button variant={'outlined'} onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className={s.state}>
+      <Typography variant={'h3'}>{emptyText}</Typography>
+    </div>
+  )
+}

--- a/src/entities/profile/ui/Profile/FollowListModal/FollowListModal.module.scss
+++ b/src/entities/profile/ui/Profile/FollowListModal/FollowListModal.module.scss
@@ -1,21 +1,98 @@
 .modal {
-  width: min(438px, calc(100vw - 32px));
+  width: min(644px, calc(100vw - 32px));
+}
+
+.modalConfirming {
+  border-color: var(--color-dark-500);
+}
+
+.modalInner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 72px;
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--color-dark-100);
+}
+
+.title {
+  padding: 0;
+}
+
+.closeButton {
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  color: var(--color-light-100);
+  background: transparent;
+  font-family: Arial, sans-serif;
+  font-size: 30px;
+  line-height: 0;
+
+  &:hover {
+    background-color: var(--color-dark-100);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--color-primary-500);
+  }
+}
+
+.modalConfirming .header {
+  justify-content: center;
+}
+
+.modalConfirming .closeButton {
+  position: absolute;
+  left: 24px;
+  color: var(--color-light-900);
+}
+
+.modalConfirming .title {
+  color: var(--color-light-900);
 }
 
 .content {
   display: flex;
   flex-direction: column;
-  min-height: 260px;
-  max-height: min(560px, calc(100vh - 180px));
+  min-height: 360px;
+  max-height: min(480px, calc(100vh - 190px));
+  padding: 24px 24px 36px;
+}
+
+.searchWrapper {
+  flex-shrink: 0;
+  margin-bottom: 14px;
 }
 
 .list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
   min-height: 0;
   overflow-y: auto;
   padding-right: 4px;
+}
+
+.userRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 58px;
+  padding: 2px 4px;
 }
 
 .userLink {
@@ -23,7 +100,8 @@
   align-items: center;
   gap: 12px;
   min-width: 0;
-  padding: 8px;
+  flex: 1;
+  padding: 6px 8px;
   border-radius: 6px;
   color: var(--color-light-100);
   text-decoration: none;
@@ -34,13 +112,20 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--color-primary-500);
-    outline-offset: 2px;
+    outline: none;
+    box-shadow: inset 0 0 0 2px var(--color-primary-500);
   }
+}
+
+.followButton {
+  flex-shrink: 0;
+  min-width: 120px;
 }
 
 .avatar {
   flex-shrink: 0;
+  width: 40px;
+  height: 40px;
 }
 
 .userInfo {
@@ -49,14 +134,12 @@
   min-width: 0;
 }
 
-.userName,
-.fullName {
+.userName {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.fullName,
 .stateText {
   color: var(--color-light-900);
 }
@@ -73,4 +156,90 @@
   padding: 12px 0;
   text-align: center;
   color: var(--color-light-900);
+}
+
+.confirmOverlay {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgb(0 0 0 / 52%);
+}
+
+.confirmModal {
+  width: min(378px, calc(100% - 32px));
+  min-height: 240px;
+  border: 1px solid var(--color-dark-100);
+  background-color: var(--color-dark-300);
+}
+
+.confirmHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 72px;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--color-dark-100);
+}
+
+.confirmTitle {
+  font-size: 20px;
+  line-height: 36px;
+}
+
+.confirmCloseButton {
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  color: var(--color-light-100);
+  background: transparent;
+  font-family: Arial, sans-serif;
+  font-size: 24px;
+  line-height: 0;
+
+  &:hover {
+    background-color: var(--color-dark-100);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--color-primary-500);
+  }
+}
+
+.confirmBody {
+  display: flex;
+  gap: 16px;
+  padding: 24px 24px 0;
+}
+
+.confirmAvatar {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+}
+
+.confirmText {
+  max-width: 260px;
+}
+
+.confirmUserName {
+  font-weight: var(--font-weight-bold);
+}
+
+.confirmActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 24px;
+  padding: 32px 24px 0;
+}
+
+.confirmButton {
+  min-width: 96px;
 }

--- a/src/entities/profile/ui/Profile/FollowListModal/FollowListModal.module.scss
+++ b/src/entities/profile/ui/Profile/FollowListModal/FollowListModal.module.scss
@@ -1,0 +1,76 @@
+.modal {
+  width: min(438px, calc(100vw - 32px));
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  min-height: 260px;
+  max-height: min(560px, calc(100vh - 180px));
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.userLink {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  padding: 8px;
+  border-radius: 6px;
+  color: var(--color-light-100);
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: var(--color-dark-500);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: 2px;
+  }
+}
+
+.avatar {
+  flex-shrink: 0;
+}
+
+.userInfo {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.userName,
+.fullName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fullName,
+.stateText {
+  color: var(--color-light-900);
+}
+
+.state {
+  display: grid;
+  gap: 8px;
+  place-items: center;
+  min-height: 220px;
+  text-align: center;
+}
+
+.loadingMore {
+  padding: 12px 0;
+  text-align: center;
+  color: var(--color-light-900);
+}

--- a/src/entities/profile/ui/Profile/FollowListModal/FollowListModal.tsx
+++ b/src/entities/profile/ui/Profile/FollowListModal/FollowListModal.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import type { UserFollowingFollowersViewModel } from '@/shared/types'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import {
+  useLazyGetFollowersByUserNameQuery,
+  useLazyGetFollowingByUserNameQuery,
+} from '@/entities/users/api'
+import { Avatar, InfiniteScrollTrigger } from '@/shared/composites'
+import { APP_ROUTES } from '@/shared/constant'
+import { Button, Modal, Typography } from '@/shared/ui'
+import Link from 'next/link'
+
+import s from './FollowListModal.module.scss'
+
+export type FollowListMode = 'following' | 'followers'
+
+type Props = {
+  mode: FollowListMode
+  onClose: () => void
+  open: boolean
+  userName: string
+}
+
+const PAGE_SIZE = 10
+
+const getTitle = (mode: FollowListMode) => (mode === 'followers' ? 'Followers' : 'Following')
+
+const getEmptyText = (mode: FollowListMode) =>
+  mode === 'followers' ? 'No followers yet' : 'No following yet'
+
+export const FollowListModal = ({ mode, onClose, open, userName }: Props) => {
+  const [users, setUsers] = useState<UserFollowingFollowersViewModel[]>([])
+  const [nextCursor, setNextCursor] = useState<number | null>(null)
+  const [isInitialLoading, setIsInitialLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [isError, setIsError] = useState(false)
+  const [triggerFollowers] = useLazyGetFollowersByUserNameQuery()
+  const [triggerFollowing] = useLazyGetFollowingByUserNameQuery()
+  const requestIdRef = useRef(0)
+  const isLoadingMoreRef = useRef(false)
+  const listRootRef = useRef<HTMLDivElement | null>(null)
+
+  const triggerQuery = useCallback(
+    (cursor?: number) => {
+      const queryArgs = { userName, pageSize: PAGE_SIZE, ...(cursor ? { cursor } : {}) }
+
+      return mode === 'followers' ? triggerFollowers(queryArgs) : triggerFollowing(queryArgs)
+    },
+    [mode, triggerFollowers, triggerFollowing, userName]
+  )
+
+  const loadFirstPage = useCallback(() => {
+    const requestId = requestIdRef.current + 1
+
+    requestIdRef.current = requestId
+    setUsers([])
+    setNextCursor(null)
+    setIsError(false)
+    setIsInitialLoading(true)
+    setIsLoadingMore(false)
+    isLoadingMoreRef.current = false
+
+    triggerQuery()
+      .unwrap()
+      .then(data => {
+        if (requestIdRef.current !== requestId) {
+          return
+        }
+
+        setUsers(data.items)
+        setNextCursor(data.nextCursor > 0 ? data.nextCursor : null)
+      })
+      .catch(() => {
+        if (requestIdRef.current !== requestId) {
+          return
+        }
+
+        setUsers([])
+        setNextCursor(null)
+        setIsError(true)
+      })
+      .finally(() => {
+        if (requestIdRef.current === requestId) {
+          setIsInitialLoading(false)
+        }
+      })
+  }, [triggerQuery])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    loadFirstPage()
+  }, [loadFirstPage, open])
+
+  const loadMore = useCallback(() => {
+    if (nextCursor === null || isLoadingMoreRef.current || isInitialLoading) {
+      return
+    }
+
+    const requestId = requestIdRef.current
+
+    isLoadingMoreRef.current = true
+    setIsLoadingMore(true)
+
+    triggerQuery(nextCursor)
+      .unwrap()
+      .then(data => {
+        if (requestIdRef.current !== requestId) {
+          return
+        }
+
+        setUsers(prev => {
+          const existingIds = new Set(prev.map(user => user.userId))
+          const newUsers = data.items.filter(user => !existingIds.has(user.userId))
+
+          return [...prev, ...newUsers]
+        })
+        setNextCursor(data.nextCursor > 0 ? data.nextCursor : null)
+      })
+      .catch(() => {
+        if (requestIdRef.current === requestId) {
+          setNextCursor(null)
+        }
+      })
+      .finally(() => {
+        if (requestIdRef.current === requestId) {
+          setIsLoadingMore(false)
+          isLoadingMoreRef.current = false
+        }
+      })
+  }, [isInitialLoading, nextCursor, triggerQuery])
+
+  const renderContent = () => {
+    if (isInitialLoading) {
+      return (
+        <div className={s.state}>
+          <Typography variant={'regular_16'}>Loading users...</Typography>
+        </div>
+      )
+    }
+
+    if (isError) {
+      return (
+        <div className={s.state}>
+          <Typography variant={'h3'}>Failed to load users</Typography>
+          <Typography className={s.stateText} variant={'regular_14'}>
+            Please try again.
+          </Typography>
+          <Button variant={'outlined'} onClick={loadFirstPage}>
+            Retry
+          </Button>
+        </div>
+      )
+    }
+
+    if (!users.length) {
+      return (
+        <div className={s.state}>
+          <Typography variant={'h3'}>{getEmptyText(mode)}</Typography>
+        </div>
+      )
+    }
+
+    return (
+      <div className={s.list} ref={listRootRef}>
+        {users.map(user => (
+          <Link
+            key={user.userId}
+            className={s.userLink}
+            href={APP_ROUTES.PROFILE.ID(user.userId)}
+            onClick={onClose}
+          >
+            <Avatar
+              className={s.avatar}
+              image={user.avatars?.[0]?.url}
+              alt={user.userName}
+              size={48}
+            />
+            <span className={s.userInfo}>
+              <Typography className={s.userName} variant={'bold_14'}>
+                {user.userName}
+              </Typography>
+            </span>
+          </Link>
+        ))}
+        {isLoadingMore && (
+          <Typography className={s.loadingMore} variant={'regular_14'}>
+            Loading more...
+          </Typography>
+        )}
+        <InfiniteScrollTrigger
+          hasNextPage={nextCursor !== null}
+          onLoadMore={loadMore}
+          rootRef={listRootRef}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} modalTitle={getTitle(mode)} className={s.modal}>
+      <div className={s.content}>{renderContent()}</div>
+    </Modal>
+  )
+}

--- a/src/entities/profile/ui/Profile/FollowListModal/FollowListModal.tsx
+++ b/src/entities/profile/ui/Profile/FollowListModal/FollowListModal.tsx
@@ -5,19 +5,24 @@ import type { UserFollowingFollowersViewModel } from '@/shared/types'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
+  useFollowUserMutation,
   useLazyGetFollowersByUserNameQuery,
   useLazyGetFollowingByUserNameQuery,
+  useUnfollowUserMutation,
 } from '@/entities/users/api'
-import { Avatar, InfiniteScrollTrigger } from '@/shared/composites'
-import { APP_ROUTES } from '@/shared/constant'
-import { Button, Modal, Typography } from '@/shared/ui'
-import Link from 'next/link'
+import { useMeQuery } from '@/features/auth'
+import { Input, Modal, Typography } from '@/shared/ui'
 
 import s from './FollowListModal.module.scss'
+
+import { FollowListFeedback } from './FollowListFeedback'
+import { FollowListUsers } from './FollowListUsers'
+import { UnfollowConfirm } from './UnfollowConfirm'
 
 export type FollowListMode = 'following' | 'followers'
 
 type Props = {
+  count: number
   mode: FollowListMode
   onClose: () => void
   open: boolean
@@ -25,18 +30,26 @@ type Props = {
 }
 
 const PAGE_SIZE = 10
+const SEARCH_DEBOUNCE_MS = 300
 
-const getTitle = (mode: FollowListMode) => (mode === 'followers' ? 'Followers' : 'Following')
+const TITLE_BY_MODE = { followers: 'Followers', following: 'Following' } as const
+const EMPTY_TEXT_BY_MODE = { followers: 'No followers yet', following: 'No following yet' } as const
+const countFormatter = new Intl.NumberFormat('ru-RU')
 
-const getEmptyText = (mode: FollowListMode) =>
-  mode === 'followers' ? 'No followers yet' : 'No following yet'
-
-export const FollowListModal = ({ mode, onClose, open, userName }: Props) => {
+export const FollowListModal = ({ count, mode, onClose, open, userName }: Props) => {
   const [users, setUsers] = useState<UserFollowingFollowersViewModel[]>([])
+  const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [nextCursor, setNextCursor] = useState<number | null>(null)
   const [isInitialLoading, setIsInitialLoading] = useState(false)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const [isError, setIsError] = useState(false)
+  const [pendingUserId, setPendingUserId] = useState<number | null>(null)
+  const [confirmUnfollowUser, setConfirmUnfollowUser] =
+    useState<UserFollowingFollowersViewModel | null>(null)
+  const { data: currentUser } = useMeQuery()
+  const [followUser] = useFollowUserMutation()
+  const [unfollowUser] = useUnfollowUserMutation()
   const [triggerFollowers] = useLazyGetFollowersByUserNameQuery()
   const [triggerFollowing] = useLazyGetFollowingByUserNameQuery()
   const requestIdRef = useRef(0)
@@ -45,11 +58,17 @@ export const FollowListModal = ({ mode, onClose, open, userName }: Props) => {
 
   const triggerQuery = useCallback(
     (cursor?: number) => {
-      const queryArgs = { userName, pageSize: PAGE_SIZE, ...(cursor ? { cursor } : {}) }
+      const trimmedSearch = debouncedSearch.trim()
+      const queryArgs = {
+        userName,
+        pageSize: PAGE_SIZE,
+        ...(cursor ? { cursor } : {}),
+        ...(trimmedSearch ? { search: trimmedSearch } : {}),
+      }
 
       return mode === 'followers' ? triggerFollowers(queryArgs) : triggerFollowing(queryArgs)
     },
-    [mode, triggerFollowers, triggerFollowing, userName]
+    [debouncedSearch, mode, triggerFollowers, triggerFollowing, userName]
   )
 
   const loadFirstPage = useCallback(() => {
@@ -69,7 +88,6 @@ export const FollowListModal = ({ mode, onClose, open, userName }: Props) => {
         if (requestIdRef.current !== requestId) {
           return
         }
-
         setUsers(data.items)
         setNextCursor(data.nextCursor > 0 ? data.nextCursor : null)
       })
@@ -77,7 +95,6 @@ export const FollowListModal = ({ mode, onClose, open, userName }: Props) => {
         if (requestIdRef.current !== requestId) {
           return
         }
-
         setUsers([])
         setNextCursor(null)
         setIsError(true)
@@ -97,6 +114,27 @@ export const FollowListModal = ({ mode, onClose, open, userName }: Props) => {
     loadFirstPage()
   }, [loadFirstPage, open])
 
+  useEffect(() => {
+    if (!open) {
+      setSearch('')
+      setDebouncedSearch('')
+
+      return
+    }
+
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearch(search)
+    }, SEARCH_DEBOUNCE_MS)
+
+    return () => clearTimeout(timeoutId)
+  }, [open, search])
+
+  useEffect(() => {
+    setSearch('')
+    setDebouncedSearch('')
+    setConfirmUnfollowUser(null)
+  }, [mode])
+
   const loadMore = useCallback(() => {
     if (nextCursor === null || isLoadingMoreRef.current || isInitialLoading) {
       return
@@ -113,7 +151,6 @@ export const FollowListModal = ({ mode, onClose, open, userName }: Props) => {
         if (requestIdRef.current !== requestId) {
           return
         }
-
         setUsers(prev => {
           const existingIds = new Set(prev.map(user => user.userId))
           const newUsers = data.items.filter(user => !existingIds.has(user.userId))
@@ -135,76 +172,113 @@ export const FollowListModal = ({ mode, onClose, open, userName }: Props) => {
       })
   }, [isInitialLoading, nextCursor, triggerQuery])
 
-  const renderContent = () => {
-    if (isInitialLoading) {
-      return (
-        <div className={s.state}>
-          <Typography variant={'regular_16'}>Loading users...</Typography>
-        </div>
+  const handleToggleFollow = async (
+    user: UserFollowingFollowersViewModel,
+    options?: { confirmed?: boolean }
+  ) => {
+    if (pendingUserId !== null || user.userId === currentUser?.userId) {
+      return
+    }
+
+    if (user.isFollowing && !options?.confirmed) {
+      setConfirmUnfollowUser(user)
+
+      return
+    }
+
+    setConfirmUnfollowUser(null)
+    setPendingUserId(user.userId)
+
+    try {
+      if (user.isFollowing) {
+        await unfollowUser({
+          currentUserId: currentUser?.userId,
+          selectedUserId: user.userId,
+          targetUserName: user.userName,
+        }).unwrap()
+      } else {
+        await followUser({
+          currentUserId: currentUser?.userId,
+          selectedUserId: user.userId,
+          targetUserName: user.userName,
+        }).unwrap()
+      }
+
+      setUsers(prev =>
+        prev.map(item =>
+          item.userId === user.userId ? { ...item, isFollowing: !user.isFollowing } : item
+        )
       )
+    } finally {
+      setPendingUserId(null)
+    }
+  }
+
+  const renderList = () => {
+    if (isInitialLoading) {
+      return <FollowListFeedback type={'loading'} />
     }
 
     if (isError) {
-      return (
-        <div className={s.state}>
-          <Typography variant={'h3'}>Failed to load users</Typography>
-          <Typography className={s.stateText} variant={'regular_14'}>
-            Please try again.
-          </Typography>
-          <Button variant={'outlined'} onClick={loadFirstPage}>
-            Retry
-          </Button>
-        </div>
-      )
+      return <FollowListFeedback type={'error'} onRetry={loadFirstPage} />
     }
 
     if (!users.length) {
-      return (
-        <div className={s.state}>
-          <Typography variant={'h3'}>{getEmptyText(mode)}</Typography>
-        </div>
-      )
+      return <FollowListFeedback type={'empty'} emptyText={EMPTY_TEXT_BY_MODE[mode]} />
     }
 
     return (
-      <div className={s.list} ref={listRootRef}>
-        {users.map(user => (
-          <Link
-            key={user.userId}
-            className={s.userLink}
-            href={APP_ROUTES.PROFILE.ID(user.userId)}
-            onClick={onClose}
-          >
-            <Avatar
-              className={s.avatar}
-              image={user.avatars?.[0]?.url}
-              alt={user.userName}
-              size={48}
-            />
-            <span className={s.userInfo}>
-              <Typography className={s.userName} variant={'bold_14'}>
-                {user.userName}
-              </Typography>
-            </span>
-          </Link>
-        ))}
-        {isLoadingMore && (
-          <Typography className={s.loadingMore} variant={'regular_14'}>
-            Loading more...
-          </Typography>
-        )}
-        <InfiniteScrollTrigger
-          hasNextPage={nextCursor !== null}
-          onLoadMore={loadMore}
-          rootRef={listRootRef}
-        />
-      </div>
+      <FollowListUsers
+        currentUserId={currentUser?.userId}
+        hasNextPage={nextCursor !== null}
+        isLoadingMore={isLoadingMore}
+        listRootRef={listRootRef}
+        pendingUserId={pendingUserId}
+        users={users}
+        onClose={onClose}
+        onLoadMore={loadMore}
+        onToggleFollow={user => void handleToggleFollow(user)}
+      />
     )
   }
 
+  const modalTitle = `${countFormatter.format(count)} ${TITLE_BY_MODE[mode]}`
+
   return (
-    <Modal open={open} onClose={onClose} modalTitle={getTitle(mode)} className={s.modal}>
-      <div className={s.content}>{renderContent()}</div>
+    <Modal
+      open={open}
+      onClose={onClose}
+      className={`${s.modal} ${confirmUnfollowUser ? s.modalConfirming : ''}`}
+    >
+      <div className={s.modalInner}>
+        <div className={s.header}>
+          <Typography className={s.title} variant={'h1'}>
+            {modalTitle}
+          </Typography>
+          <button className={s.closeButton} type={'button'} aria-label={'Close'} onClick={onClose}>
+            ×
+          </button>
+        </div>
+        <div className={s.content}>
+          <div className={s.searchWrapper}>
+            <Input
+              inputType={'search'}
+              placeholder={'Search'}
+              value={search}
+              onChange={event => setSearch(event.target.value)}
+            />
+          </div>
+          {renderList()}
+        </div>
+        {confirmUnfollowUser && (
+          <UnfollowConfirm
+            isPending={pendingUserId === confirmUnfollowUser.userId}
+            user={confirmUnfollowUser}
+            onCancel={() => setConfirmUnfollowUser(null)}
+            onConfirm={() => void handleToggleFollow(confirmUnfollowUser, { confirmed: true })}
+          />
+        )}
+      </div>
     </Modal>
   )
 }

--- a/src/entities/profile/ui/Profile/FollowListModal/FollowListUsers.tsx
+++ b/src/entities/profile/ui/Profile/FollowListModal/FollowListUsers.tsx
@@ -1,0 +1,74 @@
+import type { UserFollowingFollowersViewModel } from '@/shared/types'
+
+import type { RefObject } from 'react'
+
+import { Avatar, InfiniteScrollTrigger } from '@/shared/composites'
+import { APP_ROUTES } from '@/shared/constant'
+import { Button, Typography } from '@/shared/ui'
+import Link from 'next/link'
+
+import s from './FollowListModal.module.scss'
+
+type Props = {
+  currentUserId?: number
+  hasNextPage: boolean
+  isLoadingMore: boolean
+  listRootRef: RefObject<HTMLDivElement | null>
+  onClose: () => void
+  onLoadMore: () => void
+  onToggleFollow: (user: UserFollowingFollowersViewModel) => void
+  pendingUserId: null | number
+  users: UserFollowingFollowersViewModel[]
+}
+
+export const FollowListUsers = ({
+  currentUserId,
+  hasNextPage,
+  isLoadingMore,
+  listRootRef,
+  onClose,
+  onLoadMore,
+  onToggleFollow,
+  pendingUserId,
+  users,
+}: Props) => (
+  <div className={s.list} ref={listRootRef}>
+    {users.map(user => (
+      <div key={user.userId} className={s.userRow}>
+        <Link className={s.userLink} href={APP_ROUTES.PROFILE.ID(user.userId)} onClick={onClose}>
+          <Avatar
+            className={s.avatar}
+            image={user.avatars?.[0]?.url}
+            alt={user.userName}
+            size={48}
+          />
+          <span className={s.userInfo}>
+            <Typography className={s.userName} variant={'bold_14'}>
+              {user.userName}
+            </Typography>
+          </span>
+        </Link>
+        {user.userId !== currentUserId && (
+          <Button
+            className={s.followButton}
+            disabled={pendingUserId === user.userId}
+            variant={user.isFollowing ? 'outlined' : 'primary'}
+            onClick={() => onToggleFollow(user)}
+          >
+            {user.isFollowing ? 'Unfollow' : 'Follow'}
+          </Button>
+        )}
+      </div>
+    ))}
+    {isLoadingMore && (
+      <Typography className={s.loadingMore} variant={'regular_14'}>
+        Loading more...
+      </Typography>
+    )}
+    <InfiniteScrollTrigger
+      hasNextPage={hasNextPage}
+      onLoadMore={onLoadMore}
+      rootRef={listRootRef}
+    />
+  </div>
+)

--- a/src/entities/profile/ui/Profile/FollowListModal/UnfollowConfirm.tsx
+++ b/src/entities/profile/ui/Profile/FollowListModal/UnfollowConfirm.tsx
@@ -1,0 +1,63 @@
+import type { UserFollowingFollowersViewModel } from '@/shared/types'
+
+import { Avatar } from '@/shared/composites'
+import { Button, Typography } from '@/shared/ui'
+
+import s from './FollowListModal.module.scss'
+
+type Props = {
+  isPending: boolean
+  onCancel: () => void
+  onConfirm: () => void
+  user: UserFollowingFollowersViewModel
+}
+
+export const UnfollowConfirm = ({ isPending, onCancel, onConfirm, user }: Props) => (
+  <div className={s.confirmOverlay}>
+    <div
+      aria-labelledby={'unfollow-confirm-title'}
+      aria-modal={'true'}
+      className={s.confirmModal}
+      role={'dialog'}
+    >
+      <div className={s.confirmHeader}>
+        <Typography className={s.confirmTitle} id={'unfollow-confirm-title'} variant={'h2'}>
+          Unfollow
+        </Typography>
+        <button
+          aria-label={'Close confirmation'}
+          className={s.confirmCloseButton}
+          type={'button'}
+          onClick={onCancel}
+        >
+          ×
+        </button>
+      </div>
+      <div className={s.confirmBody}>
+        <Avatar className={s.confirmAvatar} image={user.avatars?.[0]?.url} alt={user.userName} />
+        <Typography className={s.confirmText} variant={'regular_16'}>
+          Do you really want to Unfollow from this user{' '}
+          <span className={s.confirmUserName}>“{user.userName}”</span>?
+        </Typography>
+      </div>
+      <div className={s.confirmActions}>
+        <Button
+          className={s.confirmButton}
+          disabled={isPending}
+          variant={'outlined'}
+          onClick={onConfirm}
+        >
+          Yes
+        </Button>
+        <Button
+          className={s.confirmButton}
+          disabled={isPending}
+          variant={'primary'}
+          onClick={onCancel}
+        >
+          No
+        </Button>
+      </div>
+    </div>
+  </div>
+)

--- a/src/entities/profile/ui/Profile/FollowListModal/index.ts
+++ b/src/entities/profile/ui/Profile/FollowListModal/index.ts
@@ -1,0 +1,1 @@
+export * from './FollowListModal'

--- a/src/entities/profile/ui/Profile/Profile.tsx
+++ b/src/entities/profile/ui/Profile/Profile.tsx
@@ -85,6 +85,7 @@ export function Profile({
       {followListMode && (
         <FollowListModal
           open
+          count={profile.userMetadata[followListMode]}
           mode={followListMode}
           userName={profile.userName}
           onClose={() => setFollowListMode(null)}

--- a/src/entities/profile/ui/Profile/Profile.tsx
+++ b/src/entities/profile/ui/Profile/Profile.tsx
@@ -3,6 +3,8 @@
 import type { PaginatedPosts, PostViewModel } from '@/entities/posts/api'
 import type { PostOpenSource } from '@/shared/constant'
 
+import { useState } from 'react'
+
 import {
   PostModalAuthState,
   RenderPostLikeAction,
@@ -13,6 +15,7 @@ import { InfiniteScrollTrigger, Loading } from '@/shared/composites'
 
 import s from './Profile.module.scss'
 
+import { FollowListModal, type FollowListMode } from './FollowListModal'
 import { ProfileInfo } from './ProfileInfo'
 import { ProfilePosts } from './ProfilePosts'
 
@@ -50,6 +53,7 @@ export function Profile({
     profileInfoActions,
     loadMorePostsHandler,
   } = useProfile(profileDataServer, postsDataServer, resolvedUserId)
+  const [followListMode, setFollowListMode] = useState<FollowListMode | null>(null)
 
   if (isLoading) {
     return <Loading />
@@ -64,6 +68,7 @@ export function Profile({
           shouldShowAuthActionSkeleton={shouldShowAuthActionSkeleton}
           authActionSkeletonVariant={authActionSkeletonVariant}
           isOwnProfile={isOwnProfile}
+          onStatClick={setFollowListMode}
           {...profileInfoActions}
         />
         <ProfilePosts
@@ -77,6 +82,14 @@ export function Profile({
           renderPostLikeAction={renderPostLikeAction}
         />
       </div>
+      {followListMode && (
+        <FollowListModal
+          open
+          mode={followListMode}
+          userName={profile.userName}
+          onClose={() => setFollowListMode(null)}
+        />
+      )}
       <InfiniteScrollTrigger hasNextPage={hasNextPage} onLoadMore={loadMorePostsHandler} />
     </>
   )

--- a/src/entities/profile/ui/Profile/ProfileInfo/ProfileInfo.tsx
+++ b/src/entities/profile/ui/Profile/ProfileInfo/ProfileInfo.tsx
@@ -7,7 +7,7 @@ import s from './ProfileInfo.module.scss'
 
 import { ProfileActions } from '../ProfileActions'
 import { ProfileBio } from '../ProfileBio'
-import { ProfileStats } from '../ProfileStats'
+import { ProfileStats, type ProfileStatsType } from '../ProfileStats'
 
 type Props = {
   profile: PublicProfileData
@@ -22,6 +22,7 @@ type Props = {
   onUnfollow?: () => void
   onEditProfile?: () => void
   onSendMessage?: () => void
+  onStatClick?: (type: ProfileStatsType) => void
 }
 
 export function ProfileInfo({
@@ -37,6 +38,7 @@ export function ProfileInfo({
   onUnfollow,
   onEditProfile,
   onSendMessage,
+  onStatClick,
 }: Props) {
   const { userName, avatars, aboutMe } = profile
   const isFollowing = isFollowingProp ?? profile.isFollowing
@@ -72,7 +74,7 @@ export function ProfileInfo({
             </div>
           )}
         </div>
-        <ProfileStats stats={userMetadata} />
+        <ProfileStats stats={userMetadata} onStatClick={onStatClick} />
         <ProfileBio message={aboutMe} />
       </div>
     </div>

--- a/src/entities/profile/ui/Profile/ProfileStats/ProfileStats.module.scss
+++ b/src/entities/profile/ui/Profile/ProfileStats/ProfileStats.module.scss
@@ -3,3 +3,30 @@
   gap: 80px;
   margin-bottom: 1.5rem;
 }
+
+.statButton,
+.statStatic {
+  display: grid;
+  gap: 2px;
+  min-width: 70px;
+  padding: 0;
+  color: var(--color-light-100);
+  text-align: left;
+}
+
+.statButton {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: var(--color-primary-500);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: 4px;
+  }
+}

--- a/src/entities/profile/ui/Profile/ProfileStats/ProfileStats.tsx
+++ b/src/entities/profile/ui/Profile/ProfileStats/ProfileStats.tsx
@@ -4,25 +4,37 @@ import { Typography } from '@/shared/ui'
 
 import s from './ProfileStats.module.scss'
 
+export type ProfileStatsType = 'following' | 'followers'
+
 type Props = {
+  onStatClick?: (type: ProfileStatsType) => void
   stats: UserMetadata
 }
 
-export const ProfileStats = ({ stats }: Props) => {
+export const ProfileStats = ({ onStatClick, stats }: Props) => {
   const { following, followers, publications } = stats
 
   const statsData = [
-    { label: 'Following', value: following },
-    { label: 'Followers', value: followers },
-    { label: 'Publications', value: publications },
+    { label: 'Following', value: following, type: 'following' as const },
+    { label: 'Followers', value: followers, type: 'followers' as const },
+    { label: 'Publications', value: publications, type: null },
   ]
 
   return (
     <ul className={s.stats}>
-      {statsData.map(({ label, value }) => (
+      {statsData.map(({ label, type, value }) => (
         <li key={label}>
-          <Typography variant={'bold_14'}>{value}</Typography>
-          <Typography variant={'regular_14'}>{label}</Typography>
+          {type ? (
+            <button className={s.statButton} type={'button'} onClick={() => onStatClick?.(type)}>
+              <Typography variant={'bold_14'}>{value}</Typography>
+              <Typography variant={'regular_14'}>{label}</Typography>
+            </button>
+          ) : (
+            <div className={s.statStatic}>
+              <Typography variant={'bold_14'}>{value}</Typography>
+              <Typography variant={'regular_14'}>{label}</Typography>
+            </div>
+          )}
         </li>
       ))}
     </ul>

--- a/src/entities/users/api/api.types.ts
+++ b/src/entities/users/api/api.types.ts
@@ -17,6 +17,7 @@ export type FollowListRequest = {
   userName: string
   pageSize?: number
   cursor?: number
+  search?: string
 }
 
 export type FollowListResponse = FollowingWithPaginationViewModel

--- a/src/entities/users/api/api.types.ts
+++ b/src/entities/users/api/api.types.ts
@@ -1,3 +1,5 @@
+import type { FollowingWithPaginationViewModel } from '@/shared/types'
+
 export type GetPublicPostsResponse = {
   items: PublicPostResponse[]
   pageSize: number
@@ -10,6 +12,14 @@ export type SearchUsersRequest = {
   pageSize?: number
   cursor?: number
 }
+
+export type FollowListRequest = {
+  userName: string
+  pageSize?: number
+  cursor?: number
+}
+
+export type FollowListResponse = FollowingWithPaginationViewModel
 
 export type FollowUserRequest = {
   selectedUserId: number

--- a/src/entities/users/api/index.ts
+++ b/src/entities/users/api/index.ts
@@ -2,6 +2,8 @@ export {
   publicUsersApi,
   useGetPublicUsersCounterQuery,
   useGetPublicPostsQuery,
+  useLazyGetFollowersByUserNameQuery,
+  useLazyGetFollowingByUserNameQuery,
   useSearchUsersQuery,
   useGetUserByUserNameQuery,
 } from './publicUsers.api'

--- a/src/entities/users/api/publicUsers.api.ts
+++ b/src/entities/users/api/publicUsers.api.ts
@@ -5,6 +5,8 @@ import { baseApi } from '@/shared/api/base-api'
 import {
   GetPublicPostsRequest,
   GetPublicPostsResponse,
+  FollowListRequest,
+  FollowListResponse,
   SearchUsersRequest,
   SearchUsersResponse,
   UserByUserNameResponse,
@@ -30,6 +32,18 @@ export const publicUsersApi = baseApi.injectEndpoints({
         url: API_ROUTES.USERS_FOLLOW.SEARCH,
       }),
     }),
+    getFollowersByUserName: builder.query<FollowListResponse, FollowListRequest>({
+      query: ({ userName, ...params }) => ({
+        params,
+        url: API_ROUTES.USERS_FOLLOW.FOLLOWERS_BY_USERNAME(userName),
+      }),
+    }),
+    getFollowingByUserName: builder.query<FollowListResponse, FollowListRequest>({
+      query: ({ userName, ...params }) => ({
+        params,
+        url: API_ROUTES.USERS_FOLLOW.FOLLOWING_BY_USERNAME(userName),
+      }),
+    }),
     getPublicPosts: builder.query<GetPublicPostsResponse, GetPublicPostsRequest>({
       query: ({ endCursorPostId = 0, ...params }) => ({
         params,
@@ -42,6 +56,8 @@ export const publicUsersApi = baseApi.injectEndpoints({
 export const {
   useGetPublicUsersCounterQuery,
   useGetPublicPostsQuery,
+  useLazyGetFollowersByUserNameQuery,
+  useLazyGetFollowingByUserNameQuery,
   useSearchUsersQuery,
   useGetUserByUserNameQuery,
 } = publicUsersApi


### PR DESCRIPTION
## Summary

- Jira: SCRUM-308
- What changed:
  - Added clickable `Followers` and `Following` counters on the profile page.
  - Added modal lists for followers/following users.
  - Added search inside followers/following modal lists.
  - Added follow/unfollow actions inside the modal.
  - Added confirmation modal before unfollow.
  - Added paginated API queries for followers/following by username.
  - Added navigation from the modal user row to the selected user profile.

## Scope

### In scope

- Open followers list from the `Followers` profile counter.
- Open following list from the `Following` profile counter.
- Display avatar and username in the modal list.
- Search users inside followers/following lists.
- Follow users from the modal list.
- Confirm before unfollowing users from the modal list.
- Support loading, empty, error, retry, and infinite-scroll states.
- Navigate to a user profile from the modal list.

### Out of scope

- Publications counter behavior.
- Delete/remove follower action.
- New sidebar item or separate followers/following pages.
- Existing profile hydration warning around auth action skeleton.

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

## Contract change

- What changed: Added optional `search` query param to existing followers/following list request type.
- Why: Needed to support modal search.
- Impact/Migration: None.
- Policy version updated: No.

## Mandatory checklist

- [ ] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- `pnpm typecheck` — passed
- `pnpm lint` — passed with existing `logger.ts` console warnings only
- `pnpm test:run src/entities/profile src/entities/users` — passed

### Manual

- Scenario 1: Opened own profile, clicked `Following`, verified modal opens, users are displayed, search works, scroll works, and user rows navigate to profiles.
- Scenario 2: Followed/unfollowed users from the modal and profile pages, returned to own profile, verified `Following` count and modal list update.
- Scenario 3: Opened another user profile, clicked `Followers` / `Following`, verified modal opens, search works, follow/unfollow buttons work, and profile navigation works.
- Scenario 4: Clicked `Unfollow` in the modal, verified confirmation modal appears, `No` closes it without changes, `Yes` performs unfollow.

## Risks and Rollback

- Risks:
  - Existing profile hydration warning around auth action skeleton may still appear on hard refresh; it was reproduced without this feature’s changes.
  - Backend pagination behavior depends on `nextCursor`; if API response changes, infinite scroll may need adjustment.
  - Follow/unfollow state is updated optimistically in the opened modal list; related profile counters rely on existing profile data refresh/update behavior.

- Rollback plan:
  - Revert this PR to restore previous static profile counters and remove followers/following modal queries/actions.