### PR TITLE
Scrum 306 image messages clean

### DIFF
--- a/src/app/(protected)/messenger/[id]/page.tsx
+++ b/src/app/(protected)/messenger/[id]/page.tsx
@@ -1,12 +1,13 @@
-import { ChatWindow } from '@/entities/messenger/ui/ChatWindow'
-import { MOCK_CHATS, MOCK_MESSAGES } from '@/shared/api/messenger-mocks'
+import { MessengerDialogue } from '@/widgets/messenger/ui/MessengerDialogue'
+import { notFound } from 'next/navigation'
 
 export default async function Dialogue({ params }: { params: Promise<{ id: string }> }) {
   const { id: userIdStr } = await params
   const userId = Number(userIdStr)
 
-  const chat = MOCK_CHATS.find(c => c.userId === userId)
-  const messages = MOCK_MESSAGES[userIdStr] || []
+  if (!Number.isInteger(userId) || userId <= 0) {
+    notFound()
+  }
 
-  return <ChatWindow chat={chat} messages={messages} />
+  return <MessengerDialogue partnerId={userId} />
 }

--- a/src/entities/messenger/api/messenger.api.ts
+++ b/src/entities/messenger/api/messenger.api.ts
@@ -3,6 +3,9 @@ import type {
   GetDialogueMessagesParams,
   GetMessengerDialogsParams,
   MessengerDialogsResponseDto,
+  MessageViewModel,
+  SendImageMessagePayload,
+  SendVoiceMessagePayload,
   UpdateMessagesStatusDto,
 } from '@/entities/messenger/model'
 
@@ -42,6 +45,44 @@ export const messengerApi = baseApi.injectEndpoints({
       }),
       invalidatesTags: ['MessengerDialogs', 'DialogueMessages'],
     }),
+    sendImageMessage: builder.mutation<MessageViewModel, SendImageMessagePayload>({
+      query: ({ receiverId, file, message }) => {
+        const formData = new FormData()
+
+        formData.append('file', file)
+
+        if (message !== undefined) {
+          formData.append('message', message)
+        }
+
+        return {
+          url: API_ROUTES.MESSENGER.IMAGE(receiverId),
+          method: 'POST',
+          body: formData,
+        }
+      },
+      invalidatesTags: (result, error, { receiverId }) => [
+        'MessengerDialogs',
+        { type: 'DialogueMessages', id: receiverId },
+      ],
+    }),
+    sendVoiceMessage: builder.mutation<MessageViewModel, SendVoiceMessagePayload>({
+      query: ({ receiverId, file }) => {
+        const formData = new FormData()
+
+        formData.append('file', file)
+
+        return {
+          url: API_ROUTES.MESSENGER.VOICE(receiverId),
+          method: 'POST',
+          body: formData,
+        }
+      },
+      invalidatesTags: (result, error, { receiverId }) => [
+        'MessengerDialogs',
+        { type: 'DialogueMessages', id: receiverId },
+      ],
+    }),
   }),
 })
 
@@ -52,4 +93,6 @@ export const {
   useLazyGetDialogueMessagesQuery,
   useLazyGetMessengerDialogsQuery,
   useMarkMessagesAsReadMutation,
+  useSendImageMessageMutation,
+  useSendVoiceMessageMutation,
 } = messengerApi

--- a/src/entities/messenger/lib/is-incoming-message-payload.ts
+++ b/src/entities/messenger/lib/is-incoming-message-payload.ts
@@ -1,4 +1,10 @@
-import { MessageStatus, MessageType, type MessageViewModel } from '../model/messenger.types'
+import {
+  MediaFileType,
+  MessageStatus,
+  MessageType,
+  type MediaContentViewModel,
+  type MessageViewModel,
+} from '../model/messenger.types'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null
@@ -15,6 +21,24 @@ const isMessageType = (value: unknown): value is MessageType =>
 const isMessageStatus = (value: unknown): value is MessageStatus =>
   Object.values(MessageStatus).some(status => status === value)
 
+const isMediaFileType = (value: unknown): value is MediaFileType =>
+  Object.values(MediaFileType).some(type => type === value)
+
+const isMediaContent = (value: unknown): value is MediaContentViewModel => {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return (
+    isMediaFileType(value.fileType) &&
+    typeof value.fileUrl === 'string' &&
+    value.fileUrl.length > 0 &&
+    typeof value.fileSize === 'number' &&
+    Number.isFinite(value.fileSize) &&
+    value.fileSize >= 0
+  )
+}
+
 export function isIncomingMessagePayload(payload: unknown): payload is MessageViewModel {
   if (!isRecord(payload)) {
     return false
@@ -24,7 +48,10 @@ export function isIncomingMessagePayload(payload: unknown): payload is MessageVi
     isInteger(payload.id) &&
     isInteger(payload.ownerId) &&
     isInteger(payload.receiverId) &&
-    typeof payload.messageText === 'string' &&
+    (typeof payload.messageText === 'string' || payload.messageText === null) &&
+    (payload.mediaContent === undefined ||
+      payload.mediaContent === null ||
+      isMediaContent(payload.mediaContent)) &&
     isMessageStatus(payload.status) &&
     isMessageType(payload.messageType) &&
     isDateString(payload.createdAt) &&

--- a/src/entities/messenger/lib/map-message-to-dialogue-preview.ts
+++ b/src/entities/messenger/lib/map-message-to-dialogue-preview.ts
@@ -12,7 +12,10 @@ export type DialoguePreviewUpdateResult =
       type: 'not-participant'
     }
 
-function getDialoguePartnerId(message: MessageViewModel, currentUserId: number): number | null {
+export function getDialoguePartnerId(
+  message: MessageViewModel,
+  currentUserId: number
+): number | null {
   if (message.ownerId === currentUserId) {
     return message.receiverId
   }

--- a/src/entities/messenger/model/messenger.types.ts
+++ b/src/entities/messenger/model/messenger.types.ts
@@ -12,11 +12,23 @@ export enum MessageStatus {
   READ = 'READ',
 }
 
+export enum MediaFileType {
+  IMAGE = 'image',
+  VOICE = 'voice',
+}
+
+export interface MediaContentViewModel {
+  fileType: MediaFileType
+  fileUrl: string
+  fileSize: number
+}
+
 export interface MessageViewModel {
   id: number
   ownerId: number
   receiverId: number
-  messageText: string
+  messageText: string | null
+  mediaContent?: MediaContentViewModel | null
   status: MessageStatus
   messageType: MessageType
   createdAt: string
@@ -27,6 +39,14 @@ export interface LastMessageViewDto extends MessageViewModel {
   userName: string
   avatars: AvatarViewDto[]
   notReadCount: number
+}
+
+export interface MessengerListItem {
+  userId: number
+  userName: string
+  avatarUrl?: string
+  lastMessage: string | null
+  updatedAt: string | null
 }
 
 export interface UpdateMessagesStatusDto {
@@ -62,6 +82,17 @@ export interface DialogueMessagesResponseDto {
 export interface SendMessagePayload {
   message: string
   receiverId: number
+}
+
+export interface SendImageMessagePayload {
+  receiverId: number
+  file: File
+  message?: string
+}
+
+export interface SendVoiceMessagePayload {
+  receiverId: number
+  file: File
 }
 
 export interface UpdateMessagePayload {

--- a/src/entities/messenger/model/useMessengerSocket.ts
+++ b/src/entities/messenger/model/useMessengerSocket.ts
@@ -1,11 +1,5 @@
 'use client'
 
-import type {
-  MessageAcknowledgement,
-  MessageViewModel,
-  MessengerError,
-  SendMessagePayload,
-} from './messenger.types'
 import type { UseMessengerSocketOptions, UseMessengerSocketResult } from './messenger-socket.types'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -15,8 +9,16 @@ import { logger } from '@/shared/lib/logger'
 import { io, type Socket } from 'socket.io-client'
 
 import { MESSENGER_SOCKET_EVENTS } from './messenger.events'
+import {
+  MessageType,
+  type MessageAcknowledgement,
+  type MessageViewModel,
+  type MessengerError,
+  type SendMessagePayload,
+} from './messenger.types'
 
 const WS_URL = 'https://inctagram.work'
+const AUTH_ERROR_PATTERN = /authentication|unauthorized|token|401|403/i
 
 export function useMessengerSocket({
   accessToken,
@@ -74,12 +76,18 @@ export function useMessengerSocket({
     socketRef.current = socket
 
     const reportError = (error: MessengerError) => {
-      logger.error(`[MessengerSocket] ${error.code}:`, error.message)
+      if (AUTH_ERROR_PATTERN.test(error.message)) {
+        logger.warn(`[MessengerSocket] Recovering after ${error.code}:`, error.message)
+      } else {
+        logger.error(`[MessengerSocket] ${error.code}:`, error.message)
+      }
+
       onErrorRef.current(error)
     }
 
     const processMessage = async (payload: unknown): Promise<MessageViewModel | null> => {
       if (!isIncomingMessagePayload(payload)) {
+        logger.warn('[MessengerSocket] Rejected incoming payload:', payload)
         reportError({
           source: 'socket',
           code: 'INVALID_MESSAGE_PAYLOAD',
@@ -101,7 +109,19 @@ export function useMessengerSocket({
     }
 
     const handleReceivedMessage = (payload: unknown) => {
-      void processMessage(payload)
+      const payloads = Array.isArray(payload) ? payload : [payload]
+
+      if (payloads.length === 0) {
+        reportError({
+          source: 'socket',
+          code: 'INVALID_MESSAGE_PAYLOAD',
+          message: 'Invalid incoming message payload',
+        })
+
+        return
+      }
+
+      void Promise.all(payloads.map(processMessage))
     }
 
     const handleIncomingMessage = (payload: unknown, acknowledge?: MessageAcknowledgement) => {
@@ -111,9 +131,13 @@ export function useMessengerSocket({
             return
           }
 
+          if (message.messageType !== MessageType.TEXT || message.messageText === null) {
+            return
+          }
+
           acknowledge?.({
             message: message.messageText,
-            receiverId: message.receiverId,
+            receiverId: message.ownerId,
           })
         })
         .catch(error => {
@@ -130,7 +154,14 @@ export function useMessengerSocket({
     }
 
     const handleSocketError = (error: unknown) => {
-      reportError(normalizeMessengerError(error, 'socket'))
+      const normalizedError = normalizeMessengerError(error, 'socket')
+
+      if (AUTH_ERROR_PATTERN.test(normalizedError.message)) {
+        setIsConnected(false)
+        socket.disconnect()
+      }
+
+      reportError(normalizedError)
     }
 
     socket.on('connect', handleConnect)

--- a/src/entities/messenger/ui/ChatWindow.module.scss
+++ b/src/entities/messenger/ui/ChatWindow.module.scss
@@ -14,3 +14,21 @@
   display: flex;
   flex-direction: column-reverse;
 }
+
+.addImageButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 24px;
+  height: 24px;
+
+  color: var(--color-light-100);
+  border: 2px solid var(--color-light-100);
+  border-radius: 50%;
+
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1;
+  padding-bottom: 2px;
+}

--- a/src/entities/messenger/ui/ChatWindow.tsx
+++ b/src/entities/messenger/ui/ChatWindow.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react'
 
+import { useSendImageMessageMutation } from '@/entities/messenger'
 import { MessageStatus, MessageType, type MessageViewModel } from '@/entities/messenger/model'
 import {
   ImageAttachButton,
@@ -23,6 +24,7 @@ interface ChatWindowProps {
   sendDisabled?: boolean
   error?: string | null
   isLoading?: boolean
+  receiverId: number
 }
 
 const getBubbleType = (type: MessageType) => {
@@ -63,16 +65,32 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   sendDisabled,
   error,
   isLoading = false,
+  receiverId,
 }) => {
   const [text, setText] = useState('')
 
-  const { previewUrl, error: imageError, selectImage, removeImage } = useImageMessageDraft()
+  const { file, previewUrl, error: imageError, selectImage, removeImage } = useImageMessageDraft()
+
+  const [sendImageMessage, { isLoading: isImageSending }] = useSendImageMessageMutation()
 
   const imageErrorText = getImageErrorText(imageError)
   const composerError = imageErrorText ?? error
 
-  const handleSend = () => {
+  const handleSend = async () => {
     const message = text.trim()
+
+    if (file) {
+      await sendImageMessage({
+        receiverId,
+        file,
+        message: message || undefined,
+      }).unwrap()
+
+      removeImage()
+      setText('')
+
+      return
+    }
 
     if (!message || !onSend) {
       return
@@ -133,7 +151,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         value={text}
         onChange={setText}
         onSend={handleSend}
-        disabled={!onSend || sendDisabled}
+        disabled={sendDisabled}
+        pending={isImageSending}
         previewSlot={previewSlot}
         actionsSlot={actionsSlot}
         error={composerError}

--- a/src/entities/messenger/ui/ChatWindow.tsx
+++ b/src/entities/messenger/ui/ChatWindow.tsx
@@ -68,26 +68,33 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   receiverId,
 }) => {
   const [text, setText] = useState('')
+  const [sendError, setSendError] = useState<string | null>(null)
 
   const { file, previewUrl, error: imageError, selectImage, removeImage } = useImageMessageDraft()
 
   const [sendImageMessage, { isLoading: isImageSending }] = useSendImageMessageMutation()
 
   const imageErrorText = getImageErrorText(imageError)
-  const composerError = imageErrorText ?? error
+  const composerError = imageErrorText ?? sendError ?? error
 
   const handleSend = async () => {
     const message = text.trim()
 
     if (file) {
-      await sendImageMessage({
-        receiverId,
-        file,
-        message: message || undefined,
-      }).unwrap()
+      try {
+        setSendError(null)
 
-      removeImage()
-      setText('')
+        await sendImageMessage({
+          receiverId,
+          file,
+          message: message || undefined,
+        }).unwrap()
+
+        removeImage()
+        setText('')
+      } catch {
+        setSendError('Could not send image. Try again later')
+      }
 
       return
     }
@@ -96,12 +103,13 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       return
     }
 
+    setSendError(null)
     onSend(message)
     setText('')
   }
 
   const addImageButton = (
-    <ImageAttachButton disabled={sendDisabled} onImageSelect={selectImage}>
+    <ImageAttachButton disabled={sendDisabled || isImageSending} onImageSelect={selectImage}>
       <span className={styles.addImageButton}>+</span>
     </ImageAttachButton>
   )
@@ -110,13 +118,13 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     <ImagePreview
       previewUrl={previewUrl}
       onRemove={removeImage}
-      disabled={sendDisabled}
+      disabled={sendDisabled || isImageSending}
       addSlot={addImageButton}
     />
   ) : null
 
   const actionsSlot = previewUrl ? null : (
-    <ImageAttachButton disabled={sendDisabled} onImageSelect={selectImage} />
+    <ImageAttachButton disabled={sendDisabled || isImageSending} onImageSelect={selectImage} />
   )
 
   return (
@@ -151,7 +159,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         value={text}
         onChange={setText}
         onSend={handleSend}
-        disabled={sendDisabled}
+        disabled={sendDisabled || isImageSending}
         pending={isImageSending}
         previewSlot={previewSlot}
         actionsSlot={actionsSlot}

--- a/src/entities/messenger/ui/ChatWindow.tsx
+++ b/src/entities/messenger/ui/ChatWindow.tsx
@@ -3,6 +3,11 @@
 import React, { useState } from 'react'
 
 import { MessageStatus, MessageType, type MessageViewModel } from '@/entities/messenger/model'
+import {
+  ImageAttachButton,
+  ImagePreview,
+  useImageMessageDraft,
+} from '@/features/messenger/image-message'
 import { LinearProgress } from '@/shared/composites'
 
 import styles from './ChatWindow.module.scss'
@@ -32,6 +37,18 @@ const getBubbleType = (type: MessageType) => {
   return 'text'
 }
 
+const getImageErrorText = (error: 'invalidType' | 'tooLarge' | null) => {
+  if (error === 'invalidType') {
+    return 'Only PNG or JPEG images are allowed'
+  }
+
+  if (error === 'tooLarge') {
+    return 'Image must be less than 1 MB'
+  }
+
+  return null
+}
+
 const formatTime = (value: string) =>
   new Intl.DateTimeFormat('en', {
     hour: '2-digit',
@@ -48,6 +65,12 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   isLoading = false,
 }) => {
   const [text, setText] = useState('')
+
+  const { previewUrl, error: imageError, selectImage, removeImage } = useImageMessageDraft()
+
+  const imageErrorText = getImageErrorText(imageError)
+  const composerError = imageErrorText ?? error
+
   const handleSend = () => {
     const message = text.trim()
 
@@ -58,6 +81,25 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     onSend(message)
     setText('')
   }
+
+  const addImageButton = (
+    <ImageAttachButton disabled={sendDisabled} onImageSelect={selectImage}>
+      <span className={styles.addImageButton}>+</span>
+    </ImageAttachButton>
+  )
+
+  const previewSlot = previewUrl ? (
+    <ImagePreview
+      previewUrl={previewUrl}
+      onRemove={removeImage}
+      disabled={sendDisabled}
+      addSlot={addImageButton}
+    />
+  ) : null
+
+  const actionsSlot = previewUrl ? null : (
+    <ImageAttachButton disabled={sendDisabled} onImageSelect={selectImage} />
+  )
 
   return (
     <div className={styles.container}>
@@ -92,7 +134,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         onChange={setText}
         onSend={handleSend}
         disabled={!onSend || sendDisabled}
-        error={error}
+        previewSlot={previewSlot}
+        actionsSlot={actionsSlot}
+        error={composerError}
       />
     </div>
   )

--- a/src/entities/messenger/ui/ChatWindow.tsx
+++ b/src/entities/messenger/ui/ChatWindow.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState } from 'react'
 
-import { Chat, Message } from '@/shared/api/messenger-mocks'
+import { MessageStatus, MessageType, type MessageViewModel } from '@/entities/messenger/model'
+import { LinearProgress } from '@/shared/composites'
 
 import styles from './ChatWindow.module.scss'
 
@@ -10,34 +11,76 @@ import { MessageBubble } from './MessageBubble'
 import { MessageComposer } from './MessageComposer'
 
 interface ChatWindowProps {
-  chat?: Chat
-  messages?: Message[]
+  currentUserId: number
+  messages?: MessageViewModel[]
+  partnerAvatarUrl?: string
+  onSend?: (message: string) => void
+  sendDisabled?: boolean
+  error?: string | null
+  isLoading?: boolean
 }
 
-export const ChatWindow: React.FC<ChatWindowProps> = ({ chat, messages }) => {
+const getBubbleType = (type: MessageType) => {
+  if (type === MessageType.IMAGE) {
+    return 'image'
+  }
+
+  if (type === MessageType.VOICE) {
+    return 'voice'
+  }
+
+  return 'text'
+}
+
+const formatTime = (value: string) =>
+  new Intl.DateTimeFormat('en', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(value))
+
+export const ChatWindow: React.FC<ChatWindowProps> = ({
+  currentUserId,
+  messages,
+  partnerAvatarUrl,
+  onSend,
+  sendDisabled,
+  error,
+  isLoading = false,
+}) => {
   const [text, setText] = useState('')
+  const handleSend = () => {
+    const message = text.trim()
+
+    if (!message || !onSend) {
+      return
+    }
+
+    onSend(message)
+    setText('')
+  }
 
   return (
     <div className={styles.container}>
+      <LinearProgress active={isLoading} />
       {/* Messages Area */}
       <div className={styles.messagesArea}>
-        {[...(messages || [])].reverse().map((msg, index, array) => {
-          const isIncoming = msg.senderId !== 'me'
+        {[...(messages || [])].reverse().map((message, index, array) => {
+          const isIncoming = message.ownerId !== currentUserId
           const prevMsg = array[index - 1]
-          const isPrevIncoming = prevMsg && prevMsg.senderId !== 'me'
+          const isPrevIncoming = prevMsg && prevMsg.ownerId !== currentUserId
           const showAvatar = isIncoming && !isPrevIncoming
 
           return (
             <MessageBubble
-              key={msg.id}
-              text={msg.text}
+              key={message.id}
+              text={message.messageText ?? ''}
               direction={isIncoming ? 'incoming' : 'outgoing'}
-              timestamp={msg.timestamp}
-              type={msg.type}
-              url={msg.url}
-              avatarUrl={chat?.avatarUrl}
+              timestamp={formatTime(message.createdAt)}
+              type={getBubbleType(message.messageType)}
+              url={message.mediaContent?.fileUrl}
+              avatarUrl={partnerAvatarUrl}
               showAvatar={showAvatar}
-              isRead={index % 3 === 0}
+              isRead={message.status === MessageStatus.READ}
             />
           )
         })}
@@ -47,9 +90,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ chat, messages }) => {
       <MessageComposer
         value={text}
         onChange={setText}
-        onSend={() => {
-          setText('')
-        }}
+        onSend={handleSend}
+        disabled={!onSend || sendDisabled}
+        error={error}
       />
     </div>
   )

--- a/src/entities/messenger/ui/MessageBubble.module.scss
+++ b/src/entities/messenger/ui/MessageBubble.module.scss
@@ -55,7 +55,8 @@
   background: none;
   padding: 0;
 
-  .timestamp, .statusIcon {
+  .timestamp,
+  .statusIcon {
     color: var(--color-light-100);
   }
 }
@@ -63,7 +64,6 @@
 .imageWithText {
   padding: 2px;
   padding-bottom: 8px;
-
 
   .image {
     gap: 0;
@@ -103,9 +103,11 @@
 }
 
 .imageImg {
-  border-radius: 0.5rem;
+  width: 360px;
+  height: 360px;
   max-width: 100%;
-  height: auto;
+  object-fit: cover;
+  border-radius: 2px;
 }
 
 .voiceContent {

--- a/src/features/messenger/image-message/index.ts
+++ b/src/features/messenger/image-message/index.ts
@@ -1,0 +1,3 @@
+export * from './lib'
+export * from './model'
+export * from './ui'

--- a/src/features/messenger/image-message/lib/index.ts
+++ b/src/features/messenger/image-message/lib/index.ts
@@ -1,0 +1,1 @@
+export { validateImageMessageFile, type ImageValidationError } from './validateImageMessageFile'

--- a/src/features/messenger/image-message/lib/validateImageMessageFile.ts
+++ b/src/features/messenger/image-message/lib/validateImageMessageFile.ts
@@ -1,0 +1,17 @@
+const MAX_IMAGE_MESSAGE_SIZE = 1024 * 1024
+
+const ALLOWED_IMAGE_TYPES: string[] = ['image/jpeg', 'image/png']
+
+export type ImageValidationError = 'invalidType' | 'tooLarge'
+
+export function validateImageMessageFile(file: File): ImageValidationError | null {
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+    return 'invalidType'
+  }
+
+  if (file.size > MAX_IMAGE_MESSAGE_SIZE) {
+    return 'tooLarge'
+  }
+
+  return null
+}

--- a/src/features/messenger/image-message/model/index.ts
+++ b/src/features/messenger/image-message/model/index.ts
@@ -1,0 +1,1 @@
+export { useImageMessageDraft } from './useImageMessageDraft'

--- a/src/features/messenger/image-message/model/useImageMessageDraft.ts
+++ b/src/features/messenger/image-message/model/useImageMessageDraft.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { ImageValidationError, validateImageMessageFile } from '../lib/validateImageMessageFile'
+
+export function useImageMessageDraft() {
+  const [file, setFile] = useState<File | null>(null)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [error, setError] = useState<ImageValidationError | null>(null)
+
+  const previewUrlRef = useRef<string | null>(null)
+
+  const revokePreviewUrl = useCallback(() => {
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current)
+      previewUrlRef.current = null
+    }
+  }, [])
+
+  const selectImage = useCallback(
+    (file: File) => {
+      const validationError = validateImageMessageFile(file)
+
+      if (validationError) {
+        setError(validationError)
+
+        return
+      }
+
+      revokePreviewUrl()
+
+      const newUrl = URL.createObjectURL(file)
+
+      previewUrlRef.current = newUrl
+      setFile(file)
+      setPreviewUrl(newUrl)
+      setError(null)
+    },
+    [revokePreviewUrl]
+  )
+
+  const removeImage = useCallback(() => {
+    revokePreviewUrl()
+
+    setFile(null)
+    setPreviewUrl(null)
+    setError(null)
+  }, [revokePreviewUrl])
+
+  useEffect(() => {
+    return () => {
+      revokePreviewUrl()
+    }
+  }, [revokePreviewUrl])
+
+  const clearError = useCallback(() => {
+    setError(null)
+  }, [])
+
+  return {
+    file,
+    previewUrl,
+    error,
+    hasImage: Boolean(file && previewUrl),
+    selectImage,
+    removeImage,
+    clearError,
+  }
+}

--- a/src/features/messenger/image-message/ui/ImageAttachButton.module.scss
+++ b/src/features/messenger/image-message/ui/ImageAttachButton.module.scss
@@ -1,0 +1,25 @@
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0;
+
+  color: var(--color-light-100);
+  background: transparent;
+  border: none;
+}
+
+.button:hover {
+  color: var(--color-light-100);
+  background: transparent;
+}
+
+.button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}

--- a/src/features/messenger/image-message/ui/ImageAttachButton.tsx
+++ b/src/features/messenger/image-message/ui/ImageAttachButton.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { ChangeEvent, ReactNode, useRef } from 'react'
+
+import { Button, ImageOutline } from '@/shared/ui'
+
+import styles from './ImageAttachButton.module.scss'
+
+type ImageAttachButtonProps = {
+  disabled?: boolean
+  onImageSelect: (file: File) => void
+  children?: ReactNode
+}
+
+export function ImageAttachButton({ disabled, onImageSelect, children }: ImageAttachButtonProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  const handleOpenFilePicker = () => {
+    inputRef.current?.click()
+  }
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+
+    if (!file) {
+      return
+    }
+
+    onImageSelect(file)
+    event.target.value = ''
+  }
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type={'file'}
+        accept={'image/png,image/jpeg'}
+        hidden
+        onChange={handleFileChange}
+      />
+
+      <Button
+        type={'button'}
+        variant={'text'}
+        disabled={disabled}
+        onClick={handleOpenFilePicker}
+        className={styles.button}
+      >
+        {children ?? <ImageOutline size={24} />}
+      </Button>
+    </>
+  )
+}

--- a/src/features/messenger/image-message/ui/ImagePreview.module.scss
+++ b/src/features/messenger/image-message/ui/ImagePreview.module.scss
@@ -1,0 +1,40 @@
+.preview {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.previewItem {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-radius: 2px;
+  background-color: var(--color-dark-300);
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.removeButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  min-height: 16px;
+  padding: 0;
+
+  color: var(--color-light-100);
+  background-color: var(--color-dark-900);
+  opacity: 0.8;
+  border: none;
+  border-radius: 0;
+}

--- a/src/features/messenger/image-message/ui/ImagePreview.tsx
+++ b/src/features/messenger/image-message/ui/ImagePreview.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { ReactNode } from 'react'
+
+import { Button, Close } from '@/shared/ui'
+
+import styles from './ImagePreview.module.scss'
+
+type ImagePreviewProps = {
+  previewUrl: string
+  onRemove: () => void
+  disabled?: boolean
+  addSlot?: ReactNode
+}
+
+export function ImagePreview({ previewUrl, onRemove, disabled, addSlot }: ImagePreviewProps) {
+  return (
+    <div className={styles.preview}>
+      <div className={styles.previewItem}>
+        <img src={previewUrl} alt={'Selected image'} className={styles.image} />
+
+        <Button
+          type={'button'}
+          variant={'text'}
+          onClick={onRemove}
+          disabled={disabled}
+          className={styles.removeButton}
+        >
+          <Close size={16} />
+        </Button>
+      </div>
+      {addSlot}
+    </div>
+  )
+}

--- a/src/features/messenger/image-message/ui/index.ts
+++ b/src/features/messenger/image-message/ui/index.ts
@@ -1,0 +1,2 @@
+export { ImageAttachButton } from './ImageAttachButton'
+export { ImagePreview } from './ImagePreview'

--- a/src/shared/api/api-routes.ts
+++ b/src/shared/api/api-routes.ts
@@ -29,6 +29,8 @@ export const API_ROUTES = {
     BASE: '/v1/messenger',
     DIALOGUE: (dialoguePartnerId: string) => `/v1/messenger/${dialoguePartnerId}`,
     DELETE_MESSAGE: (id: number) => `/v1/messenger/${id}`,
+    IMAGE: (receiverId: number) => `/v1/messenger/${receiverId}/image`,
+    VOICE: (receiverId: number) => `/v1/messenger/${receiverId}/voice`,
   },
 
   NOTIFICATIONS: {

--- a/src/widgets/messenger/model/index.ts
+++ b/src/widgets/messenger/model/index.ts
@@ -1,0 +1,3 @@
+export * from './messenger-list'
+export * from './useMessengerDialogueData'
+export * from './useMessengerShell'

--- a/src/widgets/messenger/model/messenger-list.ts
+++ b/src/widgets/messenger/model/messenger-list.ts
@@ -1,0 +1,64 @@
+import type { SearchUserItem } from '@/entities/users/api/api.types'
+
+import {
+  getDialoguePartnerId,
+  MessageType,
+  type LastMessageViewDto,
+  type MessengerListItem,
+} from '@/entities/messenger'
+
+const getPreview = (type: MessageType, text: string | null) => {
+  if (text) {
+    return text
+  }
+
+  if (type === MessageType.IMAGE) {
+    return 'Image'
+  }
+
+  if (type === MessageType.VOICE) {
+    return 'Voice message'
+  }
+
+  return null
+}
+
+export function buildDialogueItems(
+  dialogues: readonly LastMessageViewDto[],
+  currentUserId: number
+): MessengerListItem[] {
+  return dialogues.flatMap(dialogue => {
+    const userId = getDialoguePartnerId(dialogue, currentUserId)
+
+    return userId === null
+      ? []
+      : [
+          {
+            userId,
+            userName: dialogue.userName,
+            avatarUrl: dialogue.avatars[0]?.url,
+            lastMessage: getPreview(dialogue.messageType, dialogue.messageText),
+            updatedAt: dialogue.updatedAt,
+          },
+        ]
+  })
+}
+
+export function appendNewContactItems(
+  dialogueItems: readonly MessengerListItem[],
+  users: readonly SearchUserItem[],
+  currentUserId: number
+): MessengerListItem[] {
+  const knownIds = new Set(dialogueItems.map(item => item.userId))
+  const newContacts = users
+    .filter(user => user.id !== currentUserId && !knownIds.has(user.id))
+    .map<MessengerListItem>(user => ({
+      userId: user.id,
+      userName: user.userName,
+      avatarUrl: user.avatars[0]?.url,
+      lastMessage: 'Start a conversation',
+      updatedAt: null,
+    }))
+
+  return [...dialogueItems, ...newContacts]
+}

--- a/src/widgets/messenger/model/useMessengerDialogueData.ts
+++ b/src/widgets/messenger/model/useMessengerDialogueData.ts
@@ -1,0 +1,40 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { type MessageViewModel, useGetDialogueMessagesQuery } from '@/entities/messenger'
+import { useGetPublicProfileQuery } from '@/entities/profile'
+import { useMeQuery } from '@/features/auth'
+
+const sortMessages = (messages: readonly MessageViewModel[]) =>
+  [...messages].sort(
+    (first, second) => new Date(first.createdAt).getTime() - new Date(second.createdAt).getTime()
+  )
+
+export function useMessengerDialogueData(partnerId: number) {
+  const { data: currentUser } = useMeQuery()
+  const { data: partner } = useGetPublicProfileQuery({ profileId: partnerId })
+  const {
+    data: history,
+    isError: isHistoryError,
+    isLoading: isHistoryLoading,
+    isFetching: isHistoryFetching,
+  } = useGetDialogueMessagesQuery(
+    {
+      dialoguePartnerId: partnerId,
+      pageSize: 50,
+    },
+    {
+      refetchOnMountOrArgChange: true,
+    }
+  )
+  const messages = useMemo(() => sortMessages(history?.items ?? []), [history])
+
+  return {
+    currentUserId: currentUser?.userId ?? 0,
+    messages,
+    partnerAvatarUrl: partner?.avatars[0]?.url,
+    isLoading: isHistoryLoading || (isHistoryFetching && messages.length === 0),
+    error: isHistoryError ? 'Could not load message history' : null,
+  }
+}

--- a/src/widgets/messenger/model/useMessengerShell.ts
+++ b/src/widgets/messenger/model/useMessengerShell.ts
@@ -1,0 +1,88 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+
+import { type MessengerListItem, useGetMessengerDialogsQuery } from '@/entities/messenger'
+import { useGetPublicProfileQuery } from '@/entities/profile'
+import { useSearchUsersQuery } from '@/entities/users/api'
+import { useMeQuery } from '@/features/auth'
+import { usePathname } from 'next/navigation'
+
+import { appendNewContactItems, buildDialogueItems } from './messenger-list'
+
+const SEARCH_DEBOUNCE_MS = 200
+
+const getPartnerIdFromPath = (pathname: string) => {
+  const match = pathname.match(/^\/messenger\/(\d+)$/)
+
+  return match ? Number(match[1]) : null
+}
+
+export function useMessengerShell() {
+  const pathname = usePathname()
+  const partnerId = getPartnerIdFromPath(pathname)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const search = debouncedSearch.trim()
+  const { data: currentUser } = useMeQuery()
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setDebouncedSearch(searchQuery), SEARCH_DEBOUNCE_MS)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [searchQuery])
+
+  const {
+    data: dialogues,
+    isLoading: areDialoguesLoading,
+    isFetching: areDialoguesFetching,
+    isError: areDialoguesError,
+  } = useGetMessengerDialogsQuery(
+    {
+      pageSize: 50,
+      searchName: search || undefined,
+    },
+    {
+      refetchOnMountOrArgChange: true,
+    }
+  )
+  const {
+    data: users,
+    isLoading: areUsersLoading,
+    isFetching: areUsersFetching,
+    isError: areUsersError,
+  } = useSearchUsersQuery({ search, pageSize: 12 }, { skip: search.length === 0 })
+  const { data: activeProfile, isFetching: isActiveProfileFetching } = useGetPublicProfileQuery(
+    { profileId: partnerId ?? 0 },
+    { skip: partnerId === null }
+  )
+
+  const dialogueItems = useMemo<MessengerListItem[]>(() => {
+    if (!currentUser) {
+      return []
+    }
+
+    return buildDialogueItems(dialogues?.items ?? [], currentUser.userId)
+  }, [currentUser, dialogues])
+
+  const items = useMemo<MessengerListItem[]>(() => {
+    if (!search || !currentUser) {
+      return dialogueItems
+    }
+
+    return appendNewContactItems(dialogueItems, users?.items ?? [], currentUser.userId)
+  }, [currentUser, dialogueItems, search, users])
+
+  return {
+    activeProfile,
+    items,
+    searchQuery,
+    setSearchQuery,
+    isLoading:
+      areDialoguesLoading ||
+      areDialoguesFetching ||
+      isActiveProfileFetching ||
+      (search.length > 0 && (areUsersLoading || areUsersFetching)),
+    isError: areDialoguesError || (search.length > 0 && areUsersError),
+  }
+}

--- a/src/widgets/messenger/ui/MessengerDialogue.tsx
+++ b/src/widgets/messenger/ui/MessengerDialogue.tsx
@@ -14,6 +14,7 @@ export function MessengerDialogue({ partnerId }: MessengerDialogueProps) {
 
   return (
     <ChatWindow
+      receiverId={partnerId}
       currentUserId={currentUserId}
       messages={messages}
       partnerAvatarUrl={partnerAvatarUrl}

--- a/src/widgets/messenger/ui/MessengerDialogue.tsx
+++ b/src/widgets/messenger/ui/MessengerDialogue.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { ChatWindow } from '@/entities/messenger/ui/ChatWindow'
+
+import { useMessengerDialogueData } from '../model'
+
+interface MessengerDialogueProps {
+  partnerId: number
+}
+
+export function MessengerDialogue({ partnerId }: MessengerDialogueProps) {
+  const { currentUserId, messages, partnerAvatarUrl, isLoading, error } =
+    useMessengerDialogueData(partnerId)
+
+  return (
+    <ChatWindow
+      currentUserId={currentUserId}
+      messages={messages}
+      partnerAvatarUrl={partnerAvatarUrl}
+      isLoading={isLoading}
+      error={error}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- Jira: SCRUM-306 — UC-2 Image Messages
- What changed:
  - Added image message draft flow: validation, preview, replace and remove.
  - Connected image draft UI to the current Messenger composer.
  - Added image sending from composer through Messenger media API.
  - Added basic send error handling.
  - Included required Messenger media/data contract alignment for image messages.

## Scope

### In scope

- PNG/JPEG image selection for Messenger.
- Image validation up to 1 MB.
- Image preview in composer.
- Replacing selected image before sending.
- Removing selected image before sending.
- Sending image-only messages.
- Sending image messages with optional text.
- Rendering sent image messages in dialogue history.
- Preserving selected image and text when sending fails.
- Disabling image controls while upload is pending.

### Out of scope

- Text-only message sending.
- Multiple images in one message.
- Voice message UI.
- Global Messenger socket provider.
- Full SENT / RECEIVED / READ lifecycle.
- Unread badges and counters.
- Editing or deleting messages from UI.

## Architecture impact

- [x] No architectural boundaries changed
- [ ] Architectural change (requires policy update)

If architectural change is checked:

- add label `policy-change`
- fill `Contract change` section
- update `.ai/policy.md` version metadata

## Contract change

- What changed: Messenger media DTO/API usage was aligned with the current backend image message contract.
- Why: Image messages require `mediaContent`, image route and image send mutation according to Swagger.
- Impact/Migration: Image message UI now uses the shared Messenger API/types layer. No migration is required.
- Policy version updated: N/A

## Mandatory checklist

- [x] `pnpm run ci:check` is green
- [x] No new `any` in production code
- [x] Manual verification scenarios are listed
- [x] Risks and rollback strategy are documented

## Verification evidence

### Automated

- Commands and result:
  - `pnpm run ci:check` — passed.
  - `pnpm lint` — passed with existing warnings in `src/shared/lib/logger.ts`.
  - `pnpm typecheck` — passed.
  - `pnpm build` — passed with existing autoprefixer warnings outside SCRUM-306 scope.

### Manual

- Scenario 1:
  - Open Messenger dialogue.
  - Select PNG/JPEG image under 1 MB.
  - Verify preview is shown.
  - Replace selected image through plus button.
  - Remove selected image through close button.

- Scenario 2:
  - Send image-only message.
  - Verify request returns `201`.
  - Verify dialogue history refetches.
  - Verify sent image is rendered in the chat.

- Scenario 3:
  - Send image with optional text.
  - Verify text is sent as image message caption.
  - Verify image and text are rendered in the chat.

- Scenario 4:
  - Select file larger than 1 MB.
  - Verify validation error is shown.
  - Verify previous valid preview is not broken.

- Scenario 5:
  - Simulate network/offline error during send.
  - Verify selected image and text are preserved.
  - Verify error message is shown.
  - Verify controls are disabled while request is pending.

## Risks and Rollback

- Risks:
  - Image sending depends on backend `POST /v1/messenger/{receiverId}/image`.
  - Some Messenger media/data contract changes were included from the shared Messenger alignment branch.
  - Full realtime delivery/read status lifecycle is still outside this task.
  - Text-only sending is not implemented in this PR.

- Rollback plan:
  - Revert SCRUM-306 commits from this branch.
  - Image draft UI and image send flow are isolated and can be removed without changing unrelated app features.